### PR TITLE
feat(plan): jump navigation, in-card list scrolling, phone bottom-sheet popups

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: verify
+description: Build, launch, and drive the Lifeline web app for runtime verification.
+---
+
+# Verifying Lifeline changes in a running browser
+
+## Build + launch (web app, guest mode — no Postgres needed)
+
+The server needs Postgres, but the web app has first-class guest mode
+(localStorage) that kicks in when the API answers 401. Stub the API:
+
+```bash
+npm install && npm run build --workspace @lifeline/shared   # shared must be built first
+node -e "require('http').createServer((q,s)=>{s.writeHead(401,{'content-type':'application/json'});s.end('{}')}).listen(4001)" &
+VITE_AUTH_DISABLED=1 VITE_PROXY_TARGET=http://localhost:4001 \
+  npm run dev -w @lifeline/web -- --port 5199 --strictPort
+```
+
+- `VITE_AUTH_DISABLED=1` is REQUIRED — without it the app throws
+  (Auth0 env vars missing) and renders the error boundary.
+- Without the 401 stub, `/api` 502s are NOT treated as guest fallback:
+  plan data never becomes `ready` and every write is silently guard-blocked
+  (looks like your feature is broken when it isn't).
+
+## Driving with Playwright
+
+Global playwright (ESM import by absolute path) + preinstalled chromium:
+
+```js
+import { chromium } from 'file:///opt/node22/lib/node_modules/playwright/index.mjs';
+const browser = await chromium.launch({
+  executablePath: '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+});
+```
+
+Useful seeds via `context.addInitScript`:
+
+- `localStorage.setItem('homeViewMode', 'plan')` — land on the Daily Plan
+  (raw string, NOT JSON).
+- `localStorage.setItem('theme', 'paper')` — any of the 10 themes.
+
+## Gotchas
+
+- Plan writes are optimistic to the React Query cache but debounced 800ms
+  (`PLAN_SAVE_DEBOUNCE_MS`) before hitting localStorage — wait ≥1s before
+  asserting on `daily_plan:<date>` / `daily_plan_settings` keys.
+- `getByText('DAILY PLAN')` is ambiguous (mode-toggle tab vs masthead) —
+  use `{ exact: true }`.
+- Phone context: `{ viewport: {width: 390, height: 844}, hasTouch: true, isMobile: true }`.

--- a/apps/web/src/features/daily-plan/DailyPlan.module.css
+++ b/apps/web/src/features/daily-plan/DailyPlan.module.css
@@ -33,6 +33,9 @@
      heading sans; paper routes these to the base sans so the only display
      face is the serif — the print reference is serif + ONE quiet sans. */
   --plan-label-font: var(--font-family-heading);
+  /* Scroll-shadow ink for internally-scrolling lists: derives from the muted
+     text so it reads on both dark cards (light haze) and paper (grey haze). */
+  --plan-scroll-shadow: color-mix(in srgb, var(--plan-muted) 45%, transparent);
 }
 
 :global([data-theme='dark']) {
@@ -79,6 +82,9 @@
 
   font-size: var(--fs);
   animation: fadeIn 0.3s ease-out;
+  /* The floating jump pill hovers over the page bottom — keep the motto and
+     last card reachable above it (plus phone home bars). */
+  padding-bottom: calc(56px + env(safe-area-inset-bottom, 0px));
 }
 
 .planRoot[data-density='roomy'] {
@@ -500,6 +506,68 @@ button.weekChipToday:hover:not(:disabled) {
   padding: var(--pad);
   display: flex;
   flex-direction: column;
+}
+
+/* ── jump navigation & internal list scrolling ───────────────────────────── */
+
+/* Jump targets stop clear of the sticky top bar. */
+.card,
+.fullCard {
+  scroll-margin-top: 76px;
+}
+
+/* Landing beat after a jump — a one-shot primary ring on the target card. */
+@media (prefers-reduced-motion: no-preference) {
+  :global([data-jump-flash]) {
+    animation: jumpFlash 0.9s ease-out;
+  }
+}
+
+@keyframes jumpFlash {
+  0% {
+    box-shadow: 0 0 0 2px var(--plan-primary);
+  }
+
+  100% {
+    box-shadow: 0 0 0 2px transparent;
+  }
+}
+
+/* Long lists scroll inside their card so the page stays shallow on phones.
+   Edge shadows appear only when there is more to scroll (local-attachment
+   covers slide away with the content); momentum + contained overscroll keep
+   it feeling native on touch. */
+.scrollList {
+  display: flex;
+  flex-direction: column;
+  gap: inherit;
+  overflow-y: auto;
+  max-height: var(--scroll-max, min(48vh, 400px));
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+  scrollbar-color: var(--plan-card-border) transparent;
+  background:
+    linear-gradient(var(--scroll-bg, var(--plan-card)) 33%, transparent),
+    linear-gradient(transparent, var(--scroll-bg, var(--plan-card)) 66%) 0 100%,
+    radial-gradient(farthest-side at 50% 0, var(--plan-scroll-shadow), transparent),
+    radial-gradient(farthest-side at 50% 100%, var(--plan-scroll-shadow), transparent) 0 100%;
+  background-repeat: no-repeat;
+  background-size:
+    100% 20px,
+    100% 20px,
+    100% 8px,
+    100% 8px;
+  background-attachment: local, local, scroll, scroll;
+}
+
+/* The schedule is the day's backbone — give it a taller window. */
+.scrollTall {
+  --scroll-max: min(58vh, 560px);
+}
+
+/* Meal slot lists cap lower — four slots share one full-width card. */
+.scrollSlot {
+  --scroll-max: 280px;
 }
 
 /* ── shared row/input primitives ─────────────────────────────────────────── */

--- a/apps/web/src/features/daily-plan/DailyPlanView.tsx
+++ b/apps/web/src/features/daily-plan/DailyPlanView.tsx
@@ -35,6 +35,7 @@ import {
 } from './lib/suggestions';
 import { Masthead } from './Masthead';
 import { PlanCard } from './PlanCard';
+import { JumpSheet, type JumpSection } from './JumpSheet';
 import { PlanSettingsModal } from './PlanSettingsModal';
 import { ComposerModal } from './ComposerModal';
 import { TaskPreviewModal } from './TaskPreviewModal';
@@ -66,7 +67,8 @@ import styles from './DailyPlan.module.css';
 
 type DayPatch = Partial<DailyPlanData> | ((day: DailyPlanData) => Partial<DailyPlanData>);
 type SettingsPatch =
-  Partial<DailyPlanSettings> | ((settings: DailyPlanSettings) => Partial<DailyPlanSettings>);
+  | Partial<DailyPlanSettings>
+  | ((settings: DailyPlanSettings) => Partial<DailyPlanSettings>);
 
 export interface DailyPlanViewProps {
   /** 'today' | 'tomorrow' | 'YYYY-MM-DD' route token. */
@@ -425,6 +427,20 @@ export function DailyPlanView({
     patchSettings({ secOrder: next });
   };
 
+  // Jump-sheet reorder arrives as the VISIBLE cards' new order — splice it
+  // back into the full persisted order, leaving hidden cards in their slots.
+  const reorderVisible = useCallback(
+    (visibleNext: string[]) => {
+      const current = settingsRef.current;
+      const full = current.secOrder.filter((k) => (PLAN_GRID_KEYS as string[]).includes(k));
+      for (const key of PLAN_GRID_KEYS) if (!full.includes(key)) full.push(key);
+      const queue = visibleNext.filter((k) => full.includes(k) && !current.hidden[k]);
+      const next = full.map((k) => (current.hidden[k] ? k : (queue.shift() ?? k)));
+      patchSettings({ secOrder: next });
+    },
+    [patchSettings],
+  );
+
   // One toggle for tasks from any card (today's and tomorrow's alike).
   const toggleTask = useCallback(
     (id: string) => {
@@ -770,6 +786,48 @@ export function DailyPlanView({
     nonneg: null,
   };
 
+  // Jump-sheet registry: every visible section in its on-page order, each
+  // with a glanceable status so the sheet doubles as a mini-dashboard.
+  const habitsDoneCount = settings.habits.filter((h) => day.habits[h.id] === true).length;
+  const scheduleFilled =
+    Object.values(day.schedule).filter((t) => t.trim().length > 0).length +
+    dayTodos.filter((t) => t.dueTime !== null).length;
+  const prioFilled = day.priorities.filter((p) => p.t.trim().length > 0);
+  const gratitudeFilled = day.gratitude.filter((g) => g.trim().length > 0).length;
+  const tomorrowQueued =
+    tomorrowTodos.length + day.tomorrow.filter((t) => t.t.trim().length > 0).length;
+  const jumpStatus: Partial<Record<PlanSectionKey, string>> = {
+    schedule: scheduleFilled > 0 ? `${scheduleFilled} planned` : '',
+    focus: day.focusText.trim().length > 0 ? '✓' : '',
+    gratitude: gratitudeFilled > 0 ? `${gratitudeFilled} / ${settings.gratitudeCount}` : '',
+    priorities:
+      prioFilled.length > 0
+        ? `${prioFilled.filter((p) => p.done).length} / ${prioFilled.length} done`
+        : '',
+    habits: `${habitsDoneCount} / ${settings.habits.length}`,
+    workout: bodies.workout?.badge ?? '',
+    todo: dayTodos.length > 0 ? `${taskDone} / ${dayTodos.length} done` : '',
+    water: `${Math.min(day.water, settings.targets.water)} / ${settings.targets.water}`,
+    weight: day.weight > 0 ? `${Math.round(day.weight * 10) / 10} kg` : '',
+    tomorrow: tomorrowQueued > 0 ? `${tomorrowQueued} queued` : '',
+    meals: mastheadEnergy ? `${mastheadEnergy.intake} / ${mastheadEnergy.target} kcal` : '',
+    nonneg: `${day.nonnegs.filter(Boolean).length} / ${settings.nonnegLabels.length}`,
+  };
+  const jumpSections: JumpSection[] = [
+    // persistedOrder is pre-filtered to PLAN_GRID_KEYS members above.
+    ...(persistedOrder as PlanSectionKey[])
+      .filter((key) => !settings.hidden[key])
+      .map((key) => ({ key, label: sectionLabel(key), status: jumpStatus[key] ?? '' })),
+    ...(['meals', 'nonneg'] as const)
+      .filter((key) => !settings.hidden[key])
+      .map((key) => ({
+        key,
+        label: sectionLabel(key),
+        status: jumpStatus[key] ?? '',
+        fixed: true,
+      })),
+  ];
+
   const densityStyle = { '--colw': `${colw}px` } as CSSProperties;
 
   return (
@@ -949,7 +1007,7 @@ export function DailyPlanView({
       )}
 
       {!settings.hidden['nonneg'] && (
-        <div className={styles.fullCard}>
+        <div className={styles.fullCard} data-sec="nonneg">
           <button
             type="button"
             className={`${styles.cardCtl} ${styles.ctlHide}`}
@@ -1048,6 +1106,8 @@ export function DailyPlanView({
           openTask(todo, todo.dueDate ?? dateStr);
         }}
       />
+
+      <JumpSheet sections={jumpSections} onReorder={reorderVisible} />
     </div>
   );
 }

--- a/apps/web/src/features/daily-plan/DailyPlanView.tsx
+++ b/apps/web/src/features/daily-plan/DailyPlanView.tsx
@@ -67,8 +67,7 @@ import styles from './DailyPlan.module.css';
 
 type DayPatch = Partial<DailyPlanData> | ((day: DailyPlanData) => Partial<DailyPlanData>);
 type SettingsPatch =
-  | Partial<DailyPlanSettings>
-  | ((settings: DailyPlanSettings) => Partial<DailyPlanSettings>);
+  Partial<DailyPlanSettings> | ((settings: DailyPlanSettings) => Partial<DailyPlanSettings>);
 
 export interface DailyPlanViewProps {
   /** 'today' | 'tomorrow' | 'YYYY-MM-DD' route token. */

--- a/apps/web/src/features/daily-plan/JumpSheet.module.css
+++ b/apps/web/src/features/daily-plan/JumpSheet.module.css
@@ -1,0 +1,341 @@
+/**
+ * Jump navigation — floating pill + bottom sheet (portaled to <body>).
+ * Styled entirely off the :root --plan-* tokens, so it looks native in all
+ * ten app themes, matching the plan's own cards and section bars.
+ */
+
+/* ── floating pill ───────────────────────────────────────────────────────── */
+
+.pill {
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: calc(14px + env(safe-area-inset-bottom, 0px));
+  z-index: 900;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: min(72vw, 340px);
+  padding: 10px 16px;
+  border: 1px solid var(--plan-card-border);
+  border-radius: 999px;
+  background: var(--plan-secbar);
+  color: var(--plan-secbar-text);
+  font-family: var(--plan-label-font);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.32);
+  transition:
+    transform var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.pill:hover {
+  transform: translateX(-50%) translateY(-1px);
+  box-shadow: 0 10px 32px rgba(0, 0, 0, 0.38);
+}
+
+.pill:active {
+  transform: translateX(-50%) scale(0.97);
+}
+
+/* Center over the content column once the sidebar is on screen. */
+@media (min-width: 769px) {
+  .pill {
+    left: calc(50% + var(--sidebar-width) / 2);
+  }
+}
+
+.pillLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pillDots {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: none;
+}
+
+.pillDots i {
+  width: 3px;
+  height: 3px;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.45;
+}
+
+.pillDots i:nth-child(2) {
+  opacity: 1;
+}
+
+@media print {
+  .pill {
+    display: none;
+  }
+}
+
+/* ── scrim + sheet ───────────────────────────────────────────────────────── */
+
+/* The sheet mounts on open and unmounts after close, so entry and exit are
+   one-shot animations: slide up on mount, slide down (fill: forwards) once
+   data-open drops, then React removes it. */
+.scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 950;
+  background: var(--scrim);
+  backdrop-filter: blur(2px);
+  animation: scrimIn 0.2s ease;
+}
+
+.scrim:not([data-open]) {
+  animation: scrimOut 0.2s ease forwards;
+  pointer-events: none;
+}
+
+@keyframes scrimIn {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes scrimOut {
+  to {
+    opacity: 0;
+  }
+}
+
+.sheet {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 951;
+  margin: 0 auto;
+  width: min(640px, 100%);
+  max-height: min(78dvh, 640px);
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--plan-card-border);
+  border-bottom: none;
+  border-radius: calc(var(--plan-rad) + 4px) calc(var(--plan-rad) + 4px) 0 0;
+  background: var(--plan-card);
+  color: var(--color-text);
+  box-shadow: 0 -12px 48px rgba(0, 0, 0, 0.35);
+  padding: 6px 14px calc(14px + env(safe-area-inset-bottom, 0px));
+  animation: sheetIn 0.3s cubic-bezier(0.32, 0.72, 0.22, 1);
+}
+
+.sheet:not([data-open]) {
+  animation: sheetOut 0.24s ease-in forwards;
+  pointer-events: none;
+}
+
+@keyframes sheetIn {
+  from {
+    transform: translateY(105%);
+  }
+}
+
+@keyframes sheetOut {
+  to {
+    transform: translateY(105%);
+  }
+}
+
+.sheet:focus {
+  outline: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sheet,
+  .scrim {
+    animation-duration: 0.01s;
+  }
+
+  .pill {
+    transition: none;
+  }
+}
+
+.grabber {
+  flex: none;
+  align-self: center;
+  width: 36px;
+  height: 4px;
+  margin: 4px 0 8px;
+  border-radius: 999px;
+  background: var(--plan-rule);
+}
+
+.head {
+  flex: none;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 0 2px 10px;
+}
+
+.title {
+  font-family: var(--plan-label-font);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--plan-muted);
+}
+
+.hint {
+  font-size: 10.5px;
+  color: var(--plan-muted);
+  opacity: 0.8;
+}
+
+.close {
+  margin-left: auto;
+  align-self: center;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--plan-muted);
+  cursor: pointer;
+}
+
+.close:hover,
+.close:focus-visible {
+  border-color: var(--plan-card-border);
+  color: var(--color-text);
+}
+
+/* ── section tiles ───────────────────────────────────────────────────────── */
+
+.tileGrid {
+  position: relative; /* tiles measure against this during a drag */
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+  scrollbar-color: var(--plan-card-border) transparent;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 8px;
+  padding: 2px;
+}
+
+.tile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+  min-height: 52px;
+  padding: 9px 11px;
+  border: 1px solid var(--plan-card-border);
+  border-radius: max(6px, calc(var(--plan-rad) - 4px));
+  background: var(--plan-surface2);
+  color: var(--color-text);
+  text-align: start;
+  cursor: pointer;
+  touch-action: pan-y;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+  transition:
+    border-color var(--transition-fast),
+    background var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.tile:hover {
+  background: var(--plan-hover);
+}
+
+/* Reorderable tiles carry a quiet grip mark in the corner. */
+.tile:not(.tileFixed)::after {
+  content: '';
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 7px;
+  height: 7px;
+  background-image: radial-gradient(currentColor 1px, transparent 1.2px);
+  background-size: 4px 4px;
+  opacity: 0.35;
+}
+
+.tileCurrent {
+  border-color: var(--plan-primary);
+  background: var(--plan-today-band);
+  box-shadow: var(--plan-today-shadow);
+}
+
+.tileLifted {
+  z-index: 5;
+  cursor: grabbing;
+  border-color: var(--plan-primary);
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.4);
+  transition: none;
+}
+
+.tileLabel {
+  font-family: var(--plan-label-font);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+
+.tileStatus {
+  font-size: 10.5px;
+  color: var(--plan-muted);
+  font-variant-numeric: tabular-nums;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+/* ── footer shortcuts ────────────────────────────────────────────────────── */
+
+.foot {
+  flex: none;
+  display: flex;
+  gap: 8px;
+  padding-top: 10px;
+}
+
+.footBtn {
+  flex: 1;
+  padding: 8px;
+  border: 1px solid var(--plan-card-border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--plan-muted);
+  font-family: var(--plan-label-font);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.footBtn:hover,
+.footBtn:focus-visible {
+  background: var(--plan-hover);
+  color: var(--color-text);
+}

--- a/apps/web/src/features/daily-plan/JumpSheet.tsx
+++ b/apps/web/src/features/daily-plan/JumpSheet.tsx
@@ -1,0 +1,520 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent as ReactPointerEvent } from 'react';
+import { createPortal } from 'react-dom';
+import styles from './JumpSheet.module.css';
+
+/**
+ * Jump navigation for the Daily Plan — a floating pill naming the section
+ * currently in view, opening a bottom sheet that lists every visible section
+ * with a live status line. Tapping a tile smooth-scrolls to that card
+ * (`[data-sec]`); holding a tile lifts it (Apple home-screen style) so it can
+ * be dragged into a new spot, persisting through the same order the grid's
+ * own drag writes. Portaled to <body> like the plan's other popups, so it
+ * styles off the :root --plan-* tokens and works in every theme.
+ */
+
+export interface JumpSection {
+  key: string;
+  label: string;
+  /** One-line live status under the label ('' → label only). */
+  status?: string;
+  /** Full-width sections (meals, non-negotiables) jump but never reorder. */
+  fixed?: boolean;
+}
+
+export interface JumpSheetProps {
+  sections: JumpSection[];
+  /** Persist a new order for the reorderable (grid) sections. */
+  onReorder: (gridKeys: string[]) => void;
+}
+
+/** Hold this long without moving to lift a tile (a scroll cancels it). */
+const LIFT_MS = 300;
+/** Movement beyond this during the hold reads as a scroll, not a lift. */
+const SLOP_PX = 8;
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+function sectionEl(key: string): HTMLElement | null {
+  return document.querySelector<HTMLElement>(`[data-sec="${key}"]`);
+}
+
+interface DragState {
+  key: string;
+  el: HTMLElement;
+  pointerId: number;
+  startX: number;
+  startY: number;
+  lastX: number;
+  lastY: number;
+  /** Layout slot the tile occupied when lifted (offset coords). */
+  originLeft: number;
+  originTop: number;
+  timer: number | null;
+  lifted: boolean;
+}
+
+const preventTouchScroll = (event: TouchEvent) => event.preventDefault();
+
+export function JumpSheet({ sections, onReorder }: JumpSheetProps) {
+  const [open, setOpen] = useState(false);
+  /** null = at the top of the page (pill shows its own name, not a section). */
+  const [currentKey, setCurrentKey] = useState<string | null>(null);
+  /** Live order while a tile is lifted; null = follow props. */
+  const [preview, setPreview] = useState<string[] | null>(null);
+  const [liftedKey, setLiftedKey] = useState<string | null>(null);
+  // The sheet mounts on open and unmounts a beat after close, so the exit
+  // slide can play — and so its tiles never shadow the page's own text
+  // (screen readers and tests both see one "Water Tracker", not two).
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    if (open || !mounted) return undefined;
+    const timer = window.setTimeout(() => setMounted(false), 260);
+    return () => window.clearTimeout(timer);
+  }, [open, mounted]);
+
+  const pillRef = useRef<HTMLButtonElement | null>(null);
+  const sheetRef = useRef<HTMLDivElement | null>(null);
+  const gridRef = useRef<HTMLDivElement | null>(null);
+  const drag = useRef<DragState | null>(null);
+  const suppressClick = useRef(false);
+  const previewRef = useRef<string[] | null>(null);
+  const setPreviewBoth = (next: string[] | null) => {
+    previewRef.current = next;
+    setPreview(next);
+  };
+
+  const byKey = new Map(sections.map((s) => [s.key, s]));
+  const baseOrder = sections.map((s) => s.key);
+  // Preview may momentarily disagree with props (card hidden mid-drag) —
+  // drop unknown keys, append new ones, so every section renders exactly once.
+  const orderedKeys = (preview ?? baseOrder).filter((k) => byKey.has(k));
+  for (const key of baseOrder) if (!orderedKeys.includes(key)) orderedKeys.push(key);
+
+  // Handlers and window listeners read these through refs, synced post-render
+  // (the compiler forbids ref writes during render).
+  const sectionsRef = useRef(sections);
+  const orderedRef = useRef(orderedKeys);
+  useEffect(() => {
+    sectionsRef.current = sections;
+    orderedRef.current = orderedKeys;
+  });
+
+  // ── scrollspy: the lowest section whose top has passed the reading line ──
+  useEffect(() => {
+    let raf = 0;
+    const spy = () => {
+      raf = 0;
+      if (window.scrollY < 60) {
+        setCurrentKey(null);
+        return;
+      }
+      const line = window.innerHeight * 0.35;
+      let best: { key: string; top: number } | null = null;
+      for (const section of sectionsRef.current) {
+        const el = sectionEl(section.key);
+        if (!el) continue;
+        const top = el.getBoundingClientRect().top;
+        if (top <= line && (best === null || top > best.top)) best = { key: section.key, top };
+      }
+      setCurrentKey(best ? best.key : null);
+    };
+    const onScroll = () => {
+      if (!raf) raf = requestAnimationFrame(spy);
+    };
+    spy();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll);
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onScroll);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  // ── drag helpers (declared before the effects that reference them) ──
+  const applyLiftTransform = (d: DragState) => {
+    // Finger delta, corrected by how far the tile's own layout slot moved
+    // while the live preview reordered under it.
+    const dx = d.lastX - d.startX + (d.originLeft - d.el.offsetLeft);
+    const dy = d.lastY - d.startY + (d.originTop - d.el.offsetTop);
+    d.el.style.transform = `translate(${dx}px, ${dy}px) scale(1.05)`;
+  };
+
+  const clearDrag = (revert: boolean) => {
+    const d = drag.current;
+    if (!d) return;
+    if (d.timer !== null) window.clearTimeout(d.timer);
+    document.removeEventListener('touchmove', preventTouchScroll);
+    if (d.lifted) {
+      try {
+        d.el.releasePointerCapture(d.pointerId);
+      } catch {
+        /* pointer already gone */
+      }
+      d.el.style.transform = '';
+      setLiftedKey(null);
+      if (revert) setPreviewBoth(null);
+    }
+    drag.current = null;
+  };
+
+  const openSheet = () => {
+    setMounted(true);
+    setOpen(true);
+  };
+
+  // Closing mid-drag (Escape, scrim tap) abandons any lift cleanly.
+  const closeSheet = () => {
+    clearDrag(true);
+    setOpen(false);
+  };
+
+  // ── open/close: scroll lock, Escape, focus hand-off ──
+  useEffect(() => {
+    if (!open) return;
+    const pill = pillRef.current;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    sheetRef.current?.focus({ preventScroll: true });
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' || event.key === 'Esc') closeSheet();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener('keydown', onKey);
+      pill?.focus({ preventScroll: true });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- closeSheet only touches refs/state setters
+  }, [open]);
+
+  // Global teardown for an in-flight drag (unmount mid-drag must not leave a
+  // non-passive touchmove blocker behind).
+  useEffect(
+    () => () => {
+      if (drag.current?.timer !== null && drag.current) window.clearTimeout(drag.current.timer);
+      document.removeEventListener('touchmove', preventTouchScroll);
+    },
+    [],
+  );
+
+  const jumpTo = (key: string) => {
+    closeSheet();
+    setCurrentKey(key);
+    const el = sectionEl(key);
+    if (!el) return;
+    el.scrollIntoView?.({ behavior: prefersReducedMotion() ? 'auto' : 'smooth', block: 'start' });
+    el.setAttribute('data-jump-flash', '');
+    window.setTimeout(() => el.removeAttribute('data-jump-flash'), 950);
+  };
+
+  // ── hold-and-drag reorder ──
+  const lift = () => {
+    const d = drag.current;
+    if (!d) return;
+    d.timer = null;
+    d.lifted = true;
+    d.originLeft = d.el.offsetLeft;
+    d.originTop = d.el.offsetTop;
+    try {
+      d.el.setPointerCapture(d.pointerId);
+    } catch {
+      /* jsdom / stale pointer */
+    }
+    // The finger is stationary past the hold delay, so no scroll owns this
+    // touch yet — claim it, or the first drag movement scrolls the sheet.
+    document.addEventListener('touchmove', preventTouchScroll, { passive: false });
+    navigator.vibrate?.(10);
+    setLiftedKey(d.key);
+    applyLiftTransform(d);
+  };
+
+  const onTilePointerDown = (event: ReactPointerEvent, key: string) => {
+    if (byKey.get(key)?.fixed || event.button !== 0) return;
+    const el = event.currentTarget as HTMLElement;
+    drag.current = {
+      key,
+      el,
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      lastX: event.clientX,
+      lastY: event.clientY,
+      originLeft: el.offsetLeft,
+      originTop: el.offsetTop,
+      timer: window.setTimeout(lift, LIFT_MS),
+      lifted: false,
+    };
+  };
+
+  const onTilePointerMove = (event: ReactPointerEvent) => {
+    const d = drag.current;
+    if (!d || event.pointerId !== d.pointerId) return;
+    d.lastX = event.clientX;
+    d.lastY = event.clientY;
+    if (!d.lifted) {
+      // Still in the hold window: real movement means scroll, not lift.
+      if (Math.hypot(d.lastX - d.startX, d.lastY - d.startY) > SLOP_PX) clearDrag(true);
+      return;
+    }
+    event.preventDefault();
+    applyLiftTransform(d);
+
+    // Which tile's layout box is under the finger? (offset coords ignore the
+    // FLIP transforms mid-animation, so hit-testing stays stable.)
+    const grid = gridRef.current;
+    if (!grid) return;
+    const gridRect = grid.getBoundingClientRect();
+    let targetKey: string | null = null;
+    for (const child of grid.children) {
+      const el = child as HTMLElement;
+      const key = el.dataset['key'];
+      if (!key || key === d.key || byKey.get(key)?.fixed) continue;
+      const left = gridRect.left + el.offsetLeft - grid.scrollLeft;
+      const top = gridRect.top + el.offsetTop - grid.scrollTop;
+      if (
+        event.clientX >= left &&
+        event.clientX <= left + el.offsetWidth &&
+        event.clientY >= top &&
+        event.clientY <= top + el.offsetHeight
+      ) {
+        targetKey = key;
+        break;
+      }
+    }
+    if (!targetKey) return;
+    const base = previewRef.current ?? orderedRef.current;
+    const fromIdx = base.indexOf(d.key);
+    const targetIdx = base.indexOf(targetKey);
+    if (fromIdx === -1 || targetIdx === -1 || fromIdx === targetIdx) return;
+    const next = base.filter((k) => k !== d.key);
+    next.splice(
+      fromIdx < targetIdx ? next.indexOf(targetKey) + 1 : next.indexOf(targetKey),
+      0,
+      d.key,
+    );
+    if (next.join('|') !== base.join('|')) setPreviewBoth(next);
+  };
+
+  const onTilePointerUp = (event: ReactPointerEvent) => {
+    const d = drag.current;
+    if (!d || event.pointerId !== d.pointerId) return;
+    if (!d.lifted) {
+      // Plain tap — let the click handler jump.
+      clearDrag(false);
+      return;
+    }
+    suppressClick.current = true;
+    const finalOrder = previewRef.current;
+    clearDrag(false);
+    setPreviewBoth(null);
+    if (finalOrder && finalOrder.join('|') !== baseOrder.join('|')) {
+      onReorder(finalOrder.filter((k) => !byKey.get(k)?.fixed));
+    }
+  };
+
+  const onTilePointerCancel = () => clearDrag(true);
+
+  const onTileKeyDown = (event: ReactKeyboardEvent, key: string) => {
+    const deltas: Record<string, -1 | 1> = {
+      ArrowLeft: -1,
+      ArrowUp: -1,
+      ArrowRight: 1,
+      ArrowDown: 1,
+    };
+    const delta = deltas[event.key];
+    if (delta === undefined || byKey.get(key)?.fixed) return;
+    event.preventDefault();
+    const gridKeys = orderedKeys.filter((k) => !byKey.get(k)?.fixed);
+    const at = gridKeys.indexOf(key);
+    const to = at + delta;
+    if (at === -1 || to < 0 || to >= gridKeys.length) return;
+    const next = [...gridKeys];
+    next.splice(at, 1);
+    next.splice(to, 0, key);
+    onReorder(next);
+  };
+
+  // FLIP: when tiles land in new slots (drag preview or persisted reorder),
+  // glide them from their previous layout position. Offset coords, not
+  // rects — the lifted tile's transform must not pollute the measurements.
+  const tileSlots = useRef(new Map<string, { left: number; top: number }>());
+  useLayoutEffect(() => {
+    const grid = gridRef.current;
+    if (!grid) return;
+    const reduced = prefersReducedMotion();
+    const previous = tileSlots.current;
+    const next = new Map<string, { left: number; top: number }>();
+    for (const child of grid.children) {
+      const el = child as HTMLElement;
+      const key = el.dataset['key'];
+      if (!key) continue;
+      const pos = { left: el.offsetLeft, top: el.offsetTop };
+      next.set(key, pos);
+      const old = previous.get(key);
+      if (
+        open &&
+        !reduced &&
+        old &&
+        key !== liftedKey &&
+        typeof el.animate === 'function' &&
+        (old.left !== pos.left || old.top !== pos.top)
+      ) {
+        el.animate(
+          [
+            { transform: `translate(${old.left - pos.left}px, ${old.top - pos.top}px)` },
+            { transform: 'translate(0, 0)' },
+          ],
+          { duration: 220, easing: 'cubic-bezier(0.2, 0.8, 0.2, 1)' },
+        );
+      }
+    }
+    tileSlots.current = next;
+    // The lifted tile's slot may have moved this render — keep it under the finger.
+    if (drag.current?.lifted) applyLiftTransform(drag.current);
+  });
+
+  if (sections.length === 0) return null;
+
+  const current = currentKey ? byKey.get(currentKey) : undefined;
+
+  return createPortal(
+    <>
+      <button
+        ref={pillRef}
+        type="button"
+        className={styles.pill}
+        aria-label="Navigate sections"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={openSheet}
+      >
+        <span className={styles.pillDots} aria-hidden="true">
+          <i />
+          <i />
+          <i />
+        </span>
+        <span className={styles.pillLabel}>{current ? current.label : 'Jump to…'}</span>
+      </button>
+
+      {mounted && (
+        <>
+          <div className={styles.scrim} data-open={open || undefined} onClick={closeSheet} />
+
+          <div
+            ref={sheetRef}
+            className={styles.sheet}
+            data-open={open || undefined}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Jump to section"
+            aria-hidden={!open}
+            inert={!open}
+            tabIndex={-1}
+          >
+            <div className={styles.grabber} aria-hidden="true" />
+            <div className={styles.head}>
+              <span className={styles.title}>Sections</span>
+              <span className={styles.hint}>tap to jump · hold to rearrange</span>
+              <button
+                type="button"
+                className={styles.close}
+                aria-label="Close"
+                onClick={closeSheet}
+              >
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.6"
+                  strokeLinecap="round"
+                  aria-hidden="true"
+                >
+                  <path d="M5 5l14 14" />
+                  <path d="M19 5L5 19" />
+                </svg>
+              </button>
+            </div>
+            <div ref={gridRef} className={styles.tileGrid}>
+              {orderedKeys.map((key) => {
+                const section = byKey.get(key);
+                if (!section) return null;
+                const classes = [
+                  styles.tile,
+                  section.fixed ? styles.tileFixed : undefined,
+                  key === currentKey ? styles.tileCurrent : undefined,
+                  key === liftedKey ? styles.tileLifted : undefined,
+                ]
+                  .filter(Boolean)
+                  .join(' ');
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    data-key={key}
+                    className={classes}
+                    title={section.fixed ? undefined : 'Hold and drag (or arrow keys) to rearrange'}
+                    onPointerDown={(event) => onTilePointerDown(event, key)}
+                    onPointerMove={onTilePointerMove}
+                    onPointerUp={onTilePointerUp}
+                    onPointerCancel={onTilePointerCancel}
+                    onKeyDown={(event) => onTileKeyDown(event, key)}
+                    onContextMenu={(event) => {
+                      if (drag.current) event.preventDefault();
+                    }}
+                    onClick={() => {
+                      if (suppressClick.current) {
+                        suppressClick.current = false;
+                        return;
+                      }
+                      jumpTo(key);
+                    }}
+                  >
+                    <span className={styles.tileLabel}>{section.label}</span>
+                    {section.status ? (
+                      <span className={styles.tileStatus}>{section.status}</span>
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
+            <div className={styles.foot}>
+              <button
+                type="button"
+                className={styles.footBtn}
+                onClick={() => {
+                  closeSheet();
+                  window.scrollTo({ top: 0, behavior: prefersReducedMotion() ? 'auto' : 'smooth' });
+                }}
+              >
+                ↑ Top
+              </button>
+              <button
+                type="button"
+                className={styles.footBtn}
+                onClick={() => {
+                  closeSheet();
+                  window.scrollTo({
+                    top: document.documentElement.scrollHeight,
+                    behavior: prefersReducedMotion() ? 'auto' : 'smooth',
+                  });
+                }}
+              >
+                ↓ Bottom
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </>,
+    document.body,
+  );
+}

--- a/apps/web/src/features/daily-plan/MealsSection.tsx
+++ b/apps/web/src/features/daily-plan/MealsSection.tsx
@@ -262,7 +262,7 @@ export function MealsSection(props: MealsSectionProps) {
   const pinned = settings.presets.filter((p) => p.pinned);
 
   return (
-    <div className={styles.fullCard}>
+    <div className={styles.fullCard} data-sec="meals">
       <button
         type="button"
         className={`${styles.cardCtl} ${styles.ctlHide}`}
@@ -484,53 +484,55 @@ export function MealsSection(props: MealsSectionProps) {
                     </button>
                   </div>
                   {items.length === 0 && <div className={styles.slotEmpty}>Nothing logged yet</div>}
-                  {items.map((item, i) => (
-                    <div key={i} className={styles.mealItemRow}>
-                      <div
-                        style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}
-                      >
-                        <input
-                          dir="auto"
-                          className={styles.mealName}
-                          value={item.n}
-                          aria-label={`${SLOT_LABELS[slot]} item ${i + 1}`}
-                          onChange={(e) => updateItem(slot, i, { n: e.target.value })}
-                        />
-                        <span className={styles.mealMacro}>
-                          P {r1(num(item.p))} · C {r1(num(item.c))} · F {r1(num(item.f))}
-                        </span>
-                      </div>
-                      <input
-                        type="number"
-                        className={styles.mealKcal}
-                        value={Math.round(num(item.cal))}
-                        aria-label={`${SLOT_LABELS[slot]} item ${i + 1} kcal`}
-                        onChange={(e) => updateItem(slot, i, { cal: num(e.target.value) })}
-                      />
-                      <span className={styles.kcalUnit}>kcal</span>
-                      <button
-                        type="button"
-                        className={styles.iconBtn}
-                        title="Remove"
-                        aria-label={`Remove ${SLOT_LABELS[slot]} item ${i + 1}`}
-                        onClick={() => removeItem(slot, i)}
-                      >
-                        <svg
-                          width="11"
-                          height="11"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2.6"
-                          strokeLinecap="round"
-                          aria-hidden="true"
+                  <div className={`${styles.scrollList} ${styles.scrollSlot}`}>
+                    {items.map((item, i) => (
+                      <div key={i} className={styles.mealItemRow}>
+                        <div
+                          style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}
                         >
-                          <path d="M5 5l14 14" />
-                          <path d="M19 5L5 19" />
-                        </svg>
-                      </button>
-                    </div>
-                  ))}
+                          <input
+                            dir="auto"
+                            className={styles.mealName}
+                            value={item.n}
+                            aria-label={`${SLOT_LABELS[slot]} item ${i + 1}`}
+                            onChange={(e) => updateItem(slot, i, { n: e.target.value })}
+                          />
+                          <span className={styles.mealMacro}>
+                            P {r1(num(item.p))} · C {r1(num(item.c))} · F {r1(num(item.f))}
+                          </span>
+                        </div>
+                        <input
+                          type="number"
+                          className={styles.mealKcal}
+                          value={Math.round(num(item.cal))}
+                          aria-label={`${SLOT_LABELS[slot]} item ${i + 1} kcal`}
+                          onChange={(e) => updateItem(slot, i, { cal: num(e.target.value) })}
+                        />
+                        <span className={styles.kcalUnit}>kcal</span>
+                        <button
+                          type="button"
+                          className={styles.iconBtn}
+                          title="Remove"
+                          aria-label={`Remove ${SLOT_LABELS[slot]} item ${i + 1}`}
+                          onClick={() => removeItem(slot, i)}
+                        >
+                          <svg
+                            width="11"
+                            height="11"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2.6"
+                            strokeLinecap="round"
+                            aria-hidden="true"
+                          >
+                            <path d="M5 5l14 14" />
+                            <path d="M19 5L5 19" />
+                          </svg>
+                        </button>
+                      </div>
+                    ))}
+                  </div>
                 </div>
               );
             })}

--- a/apps/web/src/features/daily-plan/TaskPreviewModal.module.css
+++ b/apps/web/src/features/daily-plan/TaskPreviewModal.module.css
@@ -27,6 +27,56 @@
   box-shadow: 0 24px 60px var(--shadow-dark);
 }
 
+/* Phones: preview slides up as a bottom sheet instead of a floating card. */
+@media (max-width: 640px) {
+  .overlay {
+    align-items: flex-end;
+    padding: var(--space-24) 0 0;
+    overflow-y: hidden;
+  }
+
+  .overlay .sheet {
+    width: 100%;
+    margin: 0;
+    max-height: calc(100dvh - 40px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    border-bottom: none;
+    border-radius: var(--border-radius-large) var(--border-radius-large) 0 0;
+    padding-bottom: calc(var(--space-20) + env(safe-area-inset-bottom, 0px));
+    animation: preview-up 0.28s cubic-bezier(0.32, 0.72, 0.22, 1);
+  }
+
+  .sheet::before {
+    content: '';
+    flex: none;
+    align-self: center;
+    width: 36px;
+    height: 4px;
+    margin: -10px 0 -6px;
+    border-radius: 999px;
+    background: var(--color-border);
+  }
+}
+
+@keyframes preview-up {
+  from {
+    transform: translateY(28px);
+    opacity: 0.4;
+  }
+
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .overlay .sheet {
+    animation: none;
+  }
+}
+
 /* ── header ──────────────────────────────────────────────────────────────── */
 
 .head {

--- a/apps/web/src/features/daily-plan/WorkoutCard.tsx
+++ b/apps/web/src/features/daily-plan/WorkoutCard.tsx
@@ -301,74 +301,77 @@ export function WorkoutBody(props: WorkoutBodyProps) {
         <div className={styles.gymRest}>Rest day — recovery, stretching, long walk.</div>
       )}
 
-      {routine.ex.map((ex, i) => {
-        const exDone = Math.min(done[i] ?? 0, ex.sets);
-        const timed = ex.type === 'time';
-        return (
-          <div key={i} className={styles.exRow}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <span dir="auto" className={exDone >= ex.sets ? styles.exNameDone : styles.exName}>
-                {ex.n}
-              </span>
-              <span
-                style={{
-                  marginLeft: 'auto',
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: 4,
-                  flex: '0 0 auto',
-                }}
-              >
-                <DraftNumber
-                  className={styles.kgInput}
-                  value={timed ? ex.min : ex.kg}
-                  ariaLabel={`${ex.n} ${timed ? 'minutes' : 'kg'}`}
-                  commit={(raw) =>
-                    timed
-                      ? Math.max(0, Math.min(600, Math.round(raw)))
-                      : Math.max(0, Math.min(2000, raw))
-                  }
-                  onCommit={(v) => (timed ? setMin(i, v) : setKg(i, v))}
-                />
-                <span style={{ fontSize: 10, color: 'var(--plan-muted)' }}>
-                  {timed ? 'min' : 'kg'}
+      {/* Long routines scroll inside the card on phones. */}
+      <div className={styles.scrollList}>
+        {routine.ex.map((ex, i) => {
+          const exDone = Math.min(done[i] ?? 0, ex.sets);
+          const timed = ex.type === 'time';
+          return (
+            <div key={i} className={styles.exRow}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span dir="auto" className={exDone >= ex.sets ? styles.exNameDone : styles.exName}>
+                  {ex.n}
                 </span>
-              </span>
-            </div>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-              <span style={{ display: 'inline-flex', gap: 5 }}>
-                {Array.from({ length: ex.sets }, (_, k) => (
-                  <CircleCheck
-                    key={k}
-                    on={k < exDone}
-                    size={17}
-                    label={`${ex.n} ${timed ? 'round' : 'set'} ${k + 1}`}
-                    onToggle={() => tapSet(i, k)}
+                <span
+                  style={{
+                    marginLeft: 'auto',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 4,
+                    flex: '0 0 auto',
+                  }}
+                >
+                  <DraftNumber
+                    className={styles.kgInput}
+                    value={timed ? ex.min : ex.kg}
+                    ariaLabel={`${ex.n} ${timed ? 'minutes' : 'kg'}`}
+                    commit={(raw) =>
+                      timed
+                        ? Math.max(0, Math.min(600, Math.round(raw)))
+                        : Math.max(0, Math.min(2000, raw))
+                    }
+                    onCommit={(v) => (timed ? setMin(i, v) : setKg(i, v))}
                   />
-                ))}
-              </span>
-              <span className={styles.setsLabel}>
-                {timed
-                  ? `${ex.sets > 1 ? `${ex.sets} × ` : ''}${ex.min} min`
-                  : `${ex.sets} × ${ex.reps}`}
-              </span>
-              {timed ? (
-                <span className={styles.overloadHint}>
-                  {ex.kmh > 0
-                    ? `${ex.kmh} km/h${ex.incline > 0 ? ` · ${ex.incline}%` : ''}`
-                    : ex.effort}
-                </span>
-              ) : (
-                ex.last > 0 && (
-                  <span className={styles.overloadHint}>
-                    Last {fmtKg(ex.last)}kg → try {fmtKg(ex.last + 2.5)}
+                  <span style={{ fontSize: 10, color: 'var(--plan-muted)' }}>
+                    {timed ? 'min' : 'kg'}
                   </span>
-                )
-              )}
+                </span>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                <span style={{ display: 'inline-flex', gap: 5 }}>
+                  {Array.from({ length: ex.sets }, (_, k) => (
+                    <CircleCheck
+                      key={k}
+                      on={k < exDone}
+                      size={17}
+                      label={`${ex.n} ${timed ? 'round' : 'set'} ${k + 1}`}
+                      onToggle={() => tapSet(i, k)}
+                    />
+                  ))}
+                </span>
+                <span className={styles.setsLabel}>
+                  {timed
+                    ? `${ex.sets > 1 ? `${ex.sets} × ` : ''}${ex.min} min`
+                    : `${ex.sets} × ${ex.reps}`}
+                </span>
+                {timed ? (
+                  <span className={styles.overloadHint}>
+                    {ex.kmh > 0
+                      ? `${ex.kmh} km/h${ex.incline > 0 ? ` · ${ex.incline}%` : ''}`
+                      : ex.effort}
+                  </span>
+                ) : (
+                  ex.last > 0 && (
+                    <span className={styles.overloadHint}>
+                      Last {fmtKg(ex.last)}kg → try {fmtKg(ex.last + 2.5)}
+                    </span>
+                  )
+                )}
+              </div>
             </div>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div>
 
       <QuickCardio day={props.day} patchDay={props.patchDay} bodyWeightKg={props.bodyWeightKg} />
 

--- a/apps/web/src/features/daily-plan/cards.tsx
+++ b/apps/web/src/features/daily-plan/cards.tsx
@@ -299,68 +299,73 @@ export function ScheduleBody({
     .sort(byTime);
   return (
     <div className={styles.cardBody}>
-      {hours.map((time) => {
-        const suggestions = suggestionsFor(time);
-        // '13:30' lands on the '13:00' row; the chip shows the real minutes.
-        const rowTodos = todos.filter((t) => t.dueTime?.startsWith(time.slice(0, 3))).sort(byTime);
-        return (
-          <div key={time}>
-            <div className={`${styles.rowRule} ${styles.schedRow}`}>
-              <span className={styles.schedTime}>{time}</span>
-              <input
-                dir="auto"
-                className={styles.inputBare}
-                maxLength={500}
-                value={day.schedule[time] ?? ''}
-                aria-label={`Schedule ${time}`}
-                list={suggestions.length > 0 ? `plan-sched-sug-${time}` : undefined}
-                onChange={(e) => patch({ schedule: { ...day.schedule, [time]: e.target.value } })}
-              />
-              {suggestions.length > 0 && (
-                <datalist id={`plan-sched-sug-${time}`}>
-                  {suggestions.map((text) => (
-                    <option key={text} value={text} />
-                  ))}
-                </datalist>
-              )}
-              <button
-                type="button"
-                className={styles.rowAddBtn}
-                aria-label={`Add task at ${time}`}
-                onClick={() => onAddTaskAt(time)}
-              >
-                +
-              </button>
+      {/* The full day of hour rows scrolls inside the card on phones. */}
+      <div className={`${styles.scrollList} ${styles.scrollTall}`}>
+        {hours.map((time) => {
+          const suggestions = suggestionsFor(time);
+          // '13:30' lands on the '13:00' row; the chip shows the real minutes.
+          const rowTodos = todos
+            .filter((t) => t.dueTime?.startsWith(time.slice(0, 3)))
+            .sort(byTime);
+          return (
+            <div key={time}>
+              <div className={`${styles.rowRule} ${styles.schedRow}`}>
+                <span className={styles.schedTime}>{time}</span>
+                <input
+                  dir="auto"
+                  className={styles.inputBare}
+                  maxLength={500}
+                  value={day.schedule[time] ?? ''}
+                  aria-label={`Schedule ${time}`}
+                  list={suggestions.length > 0 ? `plan-sched-sug-${time}` : undefined}
+                  onChange={(e) => patch({ schedule: { ...day.schedule, [time]: e.target.value } })}
+                />
+                {suggestions.length > 0 && (
+                  <datalist id={`plan-sched-sug-${time}`}>
+                    {suggestions.map((text) => (
+                      <option key={text} value={text} />
+                    ))}
+                  </datalist>
+                )}
+                <button
+                  type="button"
+                  className={styles.rowAddBtn}
+                  aria-label={`Add task at ${time}`}
+                  onClick={() => onAddTaskAt(time)}
+                >
+                  +
+                </button>
+              </div>
+              {rowTodos.map((todo) => (
+                <SchedChip
+                  key={todo.id}
+                  todo={todo}
+                  onToggle={() => onToggleTodo(todo.id)}
+                  onOpen={onOpenTask}
+                  onToggleSubtask={onToggleSubtask}
+                />
+              ))}
             </div>
-            {rowTodos.map((todo) => (
+          );
+        })}
+        {offHours.length > 0 && (
+          <div>
+            <div className={styles.sectionMiniMuted} style={{ paddingTop: 8 }}>
+              Outside hours
+            </div>
+            {offHours.map((todo) => (
               <SchedChip
                 key={todo.id}
                 todo={todo}
+                alwaysTime
                 onToggle={() => onToggleTodo(todo.id)}
                 onOpen={onOpenTask}
                 onToggleSubtask={onToggleSubtask}
               />
             ))}
           </div>
-        );
-      })}
-      {offHours.length > 0 && (
-        <div>
-          <div className={styles.sectionMiniMuted} style={{ paddingTop: 8 }}>
-            Outside hours
-          </div>
-          {offHours.map((todo) => (
-            <SchedChip
-              key={todo.id}
-              todo={todo}
-              alwaysTime
-              onToggle={() => onToggleTodo(todo.id)}
-              onOpen={onOpenTask}
-              onToggleSubtask={onToggleSubtask}
-            />
-          ))}
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }
@@ -1016,30 +1021,32 @@ export function TodoBody(props: TodoBodyProps) {
       {todos.length === 0 && day.quick.length === 0 && (
         <div className={styles.emptyHint}>No tasks for this day yet — add one below.</div>
       )}
-      {todos.map((todo) => (
-        <TaskRow
-          key={todo.id}
-          todo={todo}
-          onToggle={() => props.onToggleTodo(todo.id)}
-          onOpen={props.onOpenTask}
-          onToggleSubtask={props.onToggleSubtask}
-        />
-      ))}
-      {/* Legacy scratch items from before quick-add created real tasks. */}
-      {day.quick.map((q, i) => (
-        <div key={`q-${i}`} className={styles.rowRule} style={{ padding: '5px 0', gap: 9 }}>
-          <SquareCheck
-            on={q.done}
-            label={`Toggle quick to-do ${q.t}`}
-            onToggle={() =>
-              patch({ quick: day.quick.map((x, j) => (j === i ? { ...x, done: !x.done } : x)) })
-            }
+      <div className={styles.scrollList}>
+        {todos.map((todo) => (
+          <TaskRow
+            key={todo.id}
+            todo={todo}
+            onToggle={() => props.onToggleTodo(todo.id)}
+            onOpen={props.onOpenTask}
+            onToggleSubtask={props.onToggleSubtask}
           />
-          <span dir="auto" className={q.done ? styles.todoTitleDone : styles.todoTitle}>
-            {q.t}
-          </span>
-        </div>
-      ))}
+        ))}
+        {/* Legacy scratch items from before quick-add created real tasks. */}
+        {day.quick.map((q, i) => (
+          <div key={`q-${i}`} className={styles.rowRule} style={{ padding: '5px 0', gap: 9 }}>
+            <SquareCheck
+              on={q.done}
+              label={`Toggle quick to-do ${q.t}`}
+              onToggle={() =>
+                patch({ quick: day.quick.map((x, j) => (j === i ? { ...x, done: !x.done } : x)) })
+              }
+            />
+            <span dir="auto" className={q.done ? styles.todoTitleDone : styles.todoTitle}>
+              {q.t}
+            </span>
+          </div>
+        ))}
+      </div>
       <div className={styles.quickAddRow}>
         {props.suggestions.length > 0 && (
           <datalist id="plan-quick-sug">
@@ -1405,15 +1412,17 @@ export function TomorrowBody({
   return (
     <div className={styles.cardBody} style={{ gap: 2 }}>
       <AddTaskRow label="Add task for tomorrow" onAdd={onAddTask} />
-      {todos.map((todo) => (
-        <TaskRow
-          key={todo.id}
-          todo={todo}
-          onToggle={() => onToggleTodo(todo.id)}
-          onOpen={onOpenTask}
-          onToggleSubtask={onToggleSubtask}
-        />
-      ))}
+      <div className={styles.scrollList}>
+        {todos.map((todo) => (
+          <TaskRow
+            key={todo.id}
+            todo={todo}
+            onToggle={() => onToggleTodo(todo.id)}
+            onOpen={onOpenTask}
+            onToggleSubtask={onToggleSubtask}
+          />
+        ))}
+      </div>
       <div className={styles.sectionMiniMuted} style={{ paddingTop: 6 }}>
         Notes
       </div>

--- a/apps/web/src/features/daily-plan/daily-plan-jump.test.tsx
+++ b/apps/web/src/features/daily-plan/daily-plan-jump.test.tsx
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../app/providers/theme-provider';
+import { renderWithProviders } from '../../test/harness';
+import { DailyPlanView } from './DailyPlanView';
+
+/**
+ * Jump navigation (guest mode): the floating pill opens the section sheet,
+ * tiles jump to their card and close the sheet, statuses read live day data,
+ * and reordering from the sheet persists through plan settings.
+ */
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+function renderPlan(dayToken = '2026-07-09') {
+  return renderWithProviders(
+    <ThemeProvider>
+      <DailyPlanView dayToken={dayToken} todos={[]} />
+    </ThemeProvider>,
+  );
+}
+
+function openSheet(user: ReturnType<typeof userEvent.setup>) {
+  return user
+    .click(screen.getByRole('button', { name: 'Navigate sections' }))
+    .then(() => screen.getByRole('dialog', { name: 'Jump to section' }));
+}
+
+describe('Daily Plan jump navigation', () => {
+  it('pill opens the sheet listing every visible section with live statuses', async () => {
+    const user = userEvent.setup();
+    renderPlan();
+    await screen.findByText('Schedule');
+
+    // Closed by default — the dialog is out of the accessibility tree.
+    expect(screen.queryByRole('dialog', { name: 'Jump to section' })).not.toBeInTheDocument();
+
+    const sheet = await openSheet(user);
+    const tiles = within(sheet).getAllByRole('button');
+    const labels = tiles.map((tile) => tile.textContent);
+    for (const expected of ['Schedule', 'Workout', 'Water Tracker', 'Meals & Nutrition']) {
+      expect(labels.some((text) => text?.includes(expected))).toBe(true);
+    }
+    // Live status: default water target is 8, nothing logged yet.
+    const water = within(sheet).getByRole('button', { name: /Water Tracker/ });
+    expect(water.textContent).toContain('0 / 8');
+  });
+
+  it('tapping a tile scrolls to the card and closes the sheet', async () => {
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    const user = userEvent.setup();
+    renderPlan();
+    await screen.findByText('Schedule');
+
+    const sheet = await openSheet(user);
+    await user.click(within(sheet).getByRole('button', { name: /Water Tracker/ }));
+
+    expect(scrollIntoView).toHaveBeenCalledWith(expect.objectContaining({ block: 'start' }));
+    expect(screen.queryByRole('dialog', { name: 'Jump to section' })).not.toBeInTheDocument();
+  });
+
+  it('hidden cards stay out of the sheet', async () => {
+    const user = userEvent.setup();
+    renderPlan();
+    await user.click(await screen.findByRole('button', { name: 'Hide Water Tracker' }));
+
+    const sheet = await openSheet(user);
+    expect(within(sheet).queryByRole('button', { name: /Water Tracker/ })).not.toBeInTheDocument();
+  });
+
+  it('arrow keys on a tile reorder the plan and persist through secOrder', async () => {
+    const user = userEvent.setup();
+    renderPlan();
+    await screen.findByText('Schedule');
+
+    const sheet = await openSheet(user);
+    const schedule = within(sheet).getByRole('button', { name: /^Schedule/ });
+    schedule.focus();
+    await user.keyboard('{ArrowRight}');
+
+    await waitFor(
+      () => {
+        const raw = window.localStorage.getItem('daily_plan_settings');
+        expect(raw).not.toBeNull();
+        const order = JSON.parse(raw as string).secOrder as string[];
+        expect(order.indexOf('focus')).toBe(0);
+        expect(order.indexOf('schedule')).toBe(1);
+      },
+      { timeout: 3000 },
+    );
+  });
+
+  it('reordering from the sheet keeps hidden cards parked in their slot', async () => {
+    const user = userEvent.setup();
+    renderPlan();
+    // Hide the second card (Focus Zone), then move Schedule one slot later —
+    // it must hop over the hidden card's parked slot.
+    await user.click(await screen.findByRole('button', { name: 'Hide Focus Zone' }));
+
+    const sheet = await openSheet(user);
+    const schedule = within(sheet).getByRole('button', { name: /^Schedule/ });
+    schedule.focus();
+    await user.keyboard('{ArrowRight}');
+
+    await waitFor(
+      () => {
+        const raw = window.localStorage.getItem('daily_plan_settings');
+        expect(raw).not.toBeNull();
+        const order = JSON.parse(raw as string).secOrder as string[];
+        // focus keeps its hidden slot; gratitude and schedule swapped.
+        expect(order.slice(0, 3)).toEqual(['gratitude', 'focus', 'schedule']);
+      },
+      { timeout: 3000 },
+    );
+  });
+});

--- a/apps/web/src/shared/ui/Modal.module.css
+++ b/apps/web/src/shared/ui/Modal.module.css
@@ -39,4 +39,56 @@
 .body {
   padding: var(--space-20);
   overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+/* Phones: the centered card becomes a bottom sheet — full width, sized by
+   the dynamic viewport (Safari's collapsing URL bar), padded past the home
+   bar, with a grabber so it reads as sheet UI. Desktop stays a card. */
+@media (max-width: 640px) {
+  .overlay {
+    align-items: flex-end;
+    padding: var(--space-24) 0 0;
+  }
+
+  .overlay .modal {
+    width: 100%;
+    max-height: calc(100dvh - 40px);
+    border-bottom: none;
+    border-radius: var(--border-radius-large) var(--border-radius-large) 0 0;
+    animation: sheet-up 0.28s cubic-bezier(0.32, 0.72, 0.22, 1);
+  }
+
+  .modal::before {
+    content: '';
+    flex: none;
+    align-self: center;
+    width: 36px;
+    height: 4px;
+    margin: 8px 0 -4px;
+    border-radius: 999px;
+    background: var(--color-border);
+  }
+
+  .body {
+    padding-bottom: calc(var(--space-20) + env(safe-area-inset-bottom, 0px));
+  }
+}
+
+@keyframes sheet-up {
+  from {
+    transform: translateY(28px);
+    opacity: 0.4;
+  }
+
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .overlay .modal {
+    animation: none;
+  }
 }


### PR DESCRIPTION
## Summary

Mobile pass on the Daily Plan — the page is deep and the new popups weren't phone-friendly. Three changes:

- **Jump navigation (`JumpSheet`)** — a floating pill above the page names the section currently in view (scrollspy) and opens a bottom sheet listing every visible section in the user's own card order, each with a live status line (habits done, sets, cups, kcal). Tapping a tile smooth-scrolls to that card (sticky-topbar-aware `scroll-margin` + a one-beat landing flash). Holding a tile lifts it Apple-home-screen style: the grid live-reorders around the finger (FLIP), and the drop persists through the same `secOrder` the grid's own drag writes — hidden cards keep their parked slot. Arrow keys reorder from the keyboard; Escape/scrim close; body scroll locks; safe-area padded; styled entirely off the `:root --plan-*` tokens so all 10 themes look native (verified dark, paper, pink).
- **Internal list scrolling (`.scrollList`)** — long lists now scroll inside their card instead of stretching the page: schedule hours, to-do and tomorrow task lists, workout exercise rows, and meal slot items. Capped height, contained overscroll, and edge shadows that only appear while there is more to scroll.
- **Bottom-sheet popups on phones (≤640px)** — the shared `Modal` (Customize / Settings / Saved Meals) and `TaskPreviewModal` become full-width bottom sheets with a grabber, `dvh`-capped height, and home-bar (`safe-area-inset-bottom`) padding. Desktop keeps the centered card. `ComposerModal` already did this and was the template.

Also adds a repo verify skill (`.claude/skills/verify/SKILL.md`) documenting the guest-mode launch recipe used to verify this in a real browser.

**Verified end-to-end** with Playwright against the dev server in guest mode at iPhone (390×844) and desktop (1360×850) viewports: scrollspy pill label, sheet statuses, tap-to-jump, internal schedule scrolling, long-press drag reorder persisting across reload, keyboard reorder, Escape/scrim close with scroll-lock restore, and bottom-anchored Customize sheet.

## Change Type
- [ ] Product behavior
- [ ] Feature scope
- [x] Frontend behavior
- [ ] Backend behavior
- [ ] API contract
- [ ] Data model
- [ ] Architecture
- [ ] Operations / deployment

## Documentation Impact
- [x] I evaluated documentation impact.
- [ ] I updated the relevant docs.
- [x] No docs update was needed, and I explained why below.

## Docs Updated

None.

## If no docs were updated, explain why

UI-only change inside the existing Daily Plan feature: no API, schema, or settings-contract changes (`secOrder`/`hidden` are reused as-is), so no docs describe the affected surface. The new `.claude/skills/verify/SKILL.md` is itself the documentation added for the verification workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV)_