### PR TITLE
fix(plan): phone card controls + touch reorder, functional-first order, pill glide-jump

### DIFF
--- a/apps/web/src/features/daily-plan/DailyPlan.module.css
+++ b/apps/web/src/features/daily-plan/DailyPlan.module.css
@@ -453,11 +453,14 @@ button.weekChipToday:hover:not(:disabled) {
  * button's click target). Habit cells get less slop — their grid is dense.
  */
 @media (pointer: coarse) {
+  /* NOT .cardCtl — it is position:absolute (top-right of the card); flipping
+     it to relative dropped all three controls into a broken in-flow strip
+     above the section bar on every touch device. Its ::after slop below works
+     against the absolute position just as well. */
   .square,
   .cupBtn,
   .iconBtn,
   .rowAddBtn,
-  .cardCtl,
   .circle {
     position: relative;
   }
@@ -482,6 +485,26 @@ button.weekChipToday:hover:not(:disabled) {
 /* The drag source dims while its ghost travels; the grid glides via FLIP. */
 .cardDragging {
   opacity: 0.35;
+}
+
+/* Long-press lift (touch reorder): the card pops like a home-screen icon
+   while the grid reflows around the finger. */
+.cardLifted {
+  z-index: 5;
+  transform: scale(1.02);
+  box-shadow:
+    0 0 0 2px var(--plan-primary),
+    0 18px 44px rgba(0, 0, 0, 0.35);
+  transition: transform 0.15s ease-out;
+}
+
+/* The section bar doubles as the touch drag handle — suppress iOS text
+   selection / callout so a long-press lifts instead of highlighting text. */
+.secbar {
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+  touch-action: pan-y;
 }
 
 .ctlGrip {

--- a/apps/web/src/features/daily-plan/DailyPlanView.tsx
+++ b/apps/web/src/features/daily-plan/DailyPlanView.tsx
@@ -812,19 +812,19 @@ export function DailyPlanView({
     meals: mastheadEnergy ? `${mastheadEnergy.intake} / ${mastheadEnergy.target} kcal` : '',
     nonneg: `${day.nonnegs.filter(Boolean).length} / ${settings.nonnegLabels.length}`,
   };
+  // Sheet order mirrors the page: meals (full-width, above the grid), then
+  // the grid cards in the user's order, then non-negotiables at the bottom.
+  const fixedSection = (key: 'meals' | 'nonneg'): JumpSection[] =>
+    settings.hidden[key]
+      ? []
+      : [{ key, label: sectionLabel(key), status: jumpStatus[key] ?? '', fixed: true }];
   const jumpSections: JumpSection[] = [
+    ...fixedSection('meals'),
     // persistedOrder is pre-filtered to PLAN_GRID_KEYS members above.
     ...(persistedOrder as PlanSectionKey[])
       .filter((key) => !settings.hidden[key])
       .map((key) => ({ key, label: sectionLabel(key), status: jumpStatus[key] ?? '' })),
-    ...(['meals', 'nonneg'] as const)
-      .filter((key) => !settings.hidden[key])
-      .map((key) => ({
-        key,
-        label: sectionLabel(key),
-        status: jumpStatus[key] ?? '',
-        fixed: true,
-      })),
+    ...fixedSection('nonneg'),
   ];
 
   const densityStyle = { '--colw': `${colw}px` } as CSSProperties;
@@ -950,9 +950,28 @@ export function DailyPlanView({
         </div>
       )}
 
+      {/* Meals leads the page (functional-first): the food diary is worked
+          all day, so it sits right under the masthead, above the grid. */}
+      {!settings.hidden['meals'] && (
+        <MealsSection
+          day={day}
+          settings={settings}
+          patchDay={patchDay}
+          patchSettings={patchSettings}
+          onHide={() => hide('meals')}
+          recentItems={recentMeals}
+          weightKg={effectiveWeightKg}
+          fatPct={lastFatPct}
+          onOpenSettings={() => setCustomizeOpen(true)}
+        />
+      )}
+
       <div
         ref={gridRef}
         className={styles.grid}
+        // MealsSection (.fullCard) carries margin-top; the grid needs its own
+        // top gap only when meals sits above it.
+        style={settings.hidden['meals'] ? undefined : { marginTop: 'var(--gap)' }}
         // Dropping in a gap between cards is as valid as dropping on one —
         // the live preview has already placed the card; just commit.
         onDragOver={(event) => {
@@ -990,20 +1009,6 @@ export function DailyPlanView({
           );
         })}
       </div>
-
-      {!settings.hidden['meals'] && (
-        <MealsSection
-          day={day}
-          settings={settings}
-          patchDay={patchDay}
-          patchSettings={patchSettings}
-          onHide={() => hide('meals')}
-          recentItems={recentMeals}
-          weightKg={effectiveWeightKg}
-          fatPct={lastFatPct}
-          onOpenSettings={() => setCustomizeOpen(true)}
-        />
-      )}
 
       {!settings.hidden['nonneg'] && (
         <div className={styles.fullCard} data-sec="nonneg">

--- a/apps/web/src/features/daily-plan/JumpSheet.module.css
+++ b/apps/web/src/features/daily-plan/JumpSheet.module.css
@@ -28,6 +28,11 @@
   text-transform: uppercase;
   cursor: pointer;
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.32);
+  /* The pill is a gesture surface (hold → glide), never a scroll handle. */
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
   transition:
     transform var(--transition-fast),
     box-shadow var(--transition-fast);
@@ -285,6 +290,14 @@
   border-color: var(--plan-primary);
   box-shadow: 0 14px 34px rgba(0, 0, 0, 0.4);
   transition: none;
+}
+
+/* Under the finger during a pill glide — release here to jump. */
+.tileGlide {
+  border-color: var(--plan-primary);
+  background: var(--plan-hover);
+  box-shadow: var(--plan-today-shadow);
+  transform: scale(1.04);
 }
 
 .tileLabel {

--- a/apps/web/src/features/daily-plan/JumpSheet.tsx
+++ b/apps/web/src/features/daily-plan/JumpSheet.tsx
@@ -83,6 +83,17 @@ export function JumpSheet({ sections, onReorder }: JumpSheetProps) {
   const gridRef = useRef<HTMLDivElement | null>(null);
   const drag = useRef<DragState | null>(null);
   const suppressClick = useRef(false);
+  // Pill glide: hold the pill → the sheet opens under the still-held finger →
+  // slide over a tile and release to jump there in one gesture.
+  const [glideKey, setGlideKey] = useState<string | null>(null);
+  const glide = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    timer: number | null;
+    active: boolean;
+  } | null>(null);
+  const suppressPillClick = useRef(false);
   const previewRef = useRef<string[] | null>(null);
   const setPreviewBoth = (next: string[] | null) => {
     previewRef.current = next;
@@ -194,11 +205,12 @@ export function JumpSheet({ sections, onReorder }: JumpSheetProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- closeSheet only touches refs/state setters
   }, [open]);
 
-  // Global teardown for an in-flight drag (unmount mid-drag must not leave a
-  // non-passive touchmove blocker behind).
+  // Global teardown for an in-flight drag or pill glide (unmount mid-gesture
+  // must not leave a non-passive touchmove blocker behind).
   useEffect(
     () => () => {
-      if (drag.current?.timer !== null && drag.current) window.clearTimeout(drag.current.timer);
+      if (drag.current?.timer != null) window.clearTimeout(drag.current.timer);
+      if (glide.current?.timer != null) window.clearTimeout(glide.current.timer);
       document.removeEventListener('touchmove', preventTouchScroll);
     },
     [],
@@ -212,6 +224,80 @@ export function JumpSheet({ sections, onReorder }: JumpSheetProps) {
     el.scrollIntoView?.({ behavior: prefersReducedMotion() ? 'auto' : 'smooth', block: 'start' });
     el.setAttribute('data-jump-flash', '');
     window.setTimeout(() => el.removeAttribute('data-jump-flash'), 950);
+  };
+
+  // ── pill glide (hold → slide → release on a tile) ──
+  const tileKeyAt = (x: number, y: number): string | null =>
+    typeof document.elementFromPoint === 'function'
+      ? (document.elementFromPoint(x, y)?.closest<HTMLElement>('[data-key]')?.dataset['key'] ??
+        null)
+      : null;
+
+  const clearGlide = () => {
+    const g = glide.current;
+    if (!g) return;
+    if (g.timer !== null) window.clearTimeout(g.timer);
+    if (g.active) {
+      document.removeEventListener('touchmove', preventTouchScroll);
+      try {
+        pillRef.current?.releasePointerCapture(g.pointerId);
+      } catch {
+        /* pointer already gone */
+      }
+      setGlideKey(null);
+    }
+    glide.current = null;
+  };
+
+  const startGlide = () => {
+    const g = glide.current;
+    if (!g) return;
+    g.timer = null;
+    g.active = true;
+    try {
+      pillRef.current?.setPointerCapture(g.pointerId);
+    } catch {
+      /* jsdom / stale pointer */
+    }
+    // Same claim as the tile lift: the finger is stationary, no scroll owns
+    // the touch — block panning so the glide tracks cleanly.
+    document.addEventListener('touchmove', preventTouchScroll, { passive: false });
+    navigator.vibrate?.(10);
+    openSheet();
+  };
+
+  const onPillPointerDown = (event: ReactPointerEvent) => {
+    if (event.button !== 0) return;
+    glide.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      timer: window.setTimeout(startGlide, 250),
+      active: false,
+    };
+  };
+
+  const onPillPointerMove = (event: ReactPointerEvent) => {
+    const g = glide.current;
+    if (!g || event.pointerId !== g.pointerId) return;
+    if (!g.active) {
+      if (Math.hypot(event.clientX - g.startX, event.clientY - g.startY) > SLOP_PX) clearGlide();
+      return;
+    }
+    event.preventDefault();
+    setGlideKey(tileKeyAt(event.clientX, event.clientY));
+  };
+
+  const onPillPointerUp = (event: ReactPointerEvent) => {
+    const g = glide.current;
+    if (!g || event.pointerId !== g.pointerId) return;
+    const wasActive = g.active;
+    clearGlide();
+    if (!wasActive) return; // quick tap — the click handler opens the sheet
+    suppressPillClick.current = true;
+    const key = tileKeyAt(event.clientX, event.clientY);
+    if (key) jumpTo(key);
+    // released off any tile: the sheet simply stays open for a normal tap
   };
 
   // ── hold-and-drag reorder ──
@@ -393,7 +479,20 @@ export function JumpSheet({ sections, onReorder }: JumpSheetProps) {
         aria-label="Navigate sections"
         aria-haspopup="dialog"
         aria-expanded={open}
-        onClick={openSheet}
+        onPointerDown={onPillPointerDown}
+        onPointerMove={onPillPointerMove}
+        onPointerUp={onPillPointerUp}
+        onPointerCancel={clearGlide}
+        onContextMenu={(event) => {
+          if (glide.current) event.preventDefault();
+        }}
+        onClick={() => {
+          if (suppressPillClick.current) {
+            suppressPillClick.current = false;
+            return;
+          }
+          openSheet();
+        }}
       >
         <span className={styles.pillDots} aria-hidden="true">
           <i />
@@ -452,6 +551,7 @@ export function JumpSheet({ sections, onReorder }: JumpSheetProps) {
                   section.fixed ? styles.tileFixed : undefined,
                   key === currentKey ? styles.tileCurrent : undefined,
                   key === liftedKey ? styles.tileLifted : undefined,
+                  key === glideKey ? styles.tileGlide : undefined,
                 ]
                   .filter(Boolean)
                   .join(' ');

--- a/apps/web/src/features/daily-plan/PlanCard.tsx
+++ b/apps/web/src/features/daily-plan/PlanCard.tsx
@@ -1,7 +1,16 @@
-import { useEffect, useRef } from 'react';
-import type { DragEvent, ReactNode } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import type { DragEvent, PointerEvent as ReactPointerEvent, ReactNode } from 'react';
 import { masonryRowSpan } from './lib/masonry';
 import styles from './DailyPlan.module.css';
+
+/** Hold the section bar this long without moving to lift the card (touch reorder). */
+const LIFT_MS = 350;
+/** Movement beyond this during the hold reads as a scroll, not a lift. */
+const SLOP_PX = 8;
+/** Viewport band near the top/bottom edge that auto-scrolls while dragging. */
+const EDGE_PX = 96;
+
+const preventTouchScroll = (event: TouchEvent) => event.preventDefault();
 
 export interface PlanCardProps {
   secKey: string;
@@ -32,9 +41,16 @@ export interface PlanCardProps {
  * ⇄ (1↔2 panels), hide ✕. Controls fade in on card hover/focus (CSS).
  * The card measures itself (ResizeObserver) and sets its grid-row span so the
  * dense grid packs like masonry.
+ *
+ * Touch reorder: HTML5 drag never fires on touch, so the section bar doubles
+ * as a hold-to-lift handle — press ~350ms (a scroll cancels it), the card
+ * pops, the grid live-reorders under the finger through the same
+ * onDragOver/onDrop wiring the grip uses, and the viewport auto-scrolls near
+ * its edges so far-away slots are reachable.
  */
 export function PlanCard(props: PlanCardProps) {
   const ref = useRef<HTMLDivElement | null>(null);
+  const [lifted, setLifted] = useState(false);
 
   useEffect(() => {
     const el = ref.current;
@@ -56,10 +72,130 @@ export function PlanCard(props: PlanCardProps) {
     props.onDropOnKey(props.secKey);
   };
 
+  // ── hold-to-lift touch reorder ──
+  const press = useRef<{
+    pointerId: number;
+    el: HTMLElement;
+    startX: number;
+    startY: number;
+    lastX: number;
+    lastY: number;
+    timer: number | null;
+    lifted: boolean;
+    raf: number;
+  } | null>(null);
+
+  const hitTest = () => {
+    const p = press.current;
+    if (!p || typeof document.elementFromPoint !== 'function') return;
+    const over = document.elementFromPoint(p.lastX, p.lastY)?.closest<HTMLElement>('[data-sec]')
+      ?.dataset['sec'];
+    if (over && over !== props.secKey) props.onDragOverKey(over);
+  };
+
+  // Edge auto-scroll loop: holding near the viewport edge keeps scrolling
+  // (pointermove alone stalls when the finger is stationary).
+  const edgeLoop = () => {
+    const p = press.current;
+    if (!p || !p.lifted) return;
+    if (p.lastY < EDGE_PX) window.scrollBy(0, -14);
+    else if (p.lastY > window.innerHeight - EDGE_PX) window.scrollBy(0, 14);
+    hitTest();
+    p.raf = requestAnimationFrame(edgeLoop);
+  };
+
+  const clearPress = () => {
+    const p = press.current;
+    if (!p) return;
+    if (p.timer !== null) window.clearTimeout(p.timer);
+    cancelAnimationFrame(p.raf);
+    document.removeEventListener('touchmove', preventTouchScroll);
+    if (p.lifted) {
+      try {
+        p.el.releasePointerCapture(p.pointerId);
+      } catch {
+        /* pointer already gone */
+      }
+      setLifted(false);
+    }
+    press.current = null;
+  };
+
+  useEffect(() => clearPress, []);
+
+  const lift = () => {
+    const p = press.current;
+    if (!p) return;
+    p.timer = null;
+    p.lifted = true;
+    try {
+      p.el.setPointerCapture(p.pointerId);
+    } catch {
+      /* jsdom / stale pointer */
+    }
+    // Finger held still past the delay — no scroll owns this touch yet, so
+    // claim it before the first drag movement pans the page instead.
+    document.addEventListener('touchmove', preventTouchScroll, { passive: false });
+    navigator.vibrate?.(10);
+    setLifted(true);
+    props.onDragStartKey(props.secKey);
+    p.raf = requestAnimationFrame(edgeLoop);
+  };
+
+  const onBarPointerDown = (event: ReactPointerEvent) => {
+    if (event.button !== 0) return;
+    press.current = {
+      pointerId: event.pointerId,
+      el: event.currentTarget as HTMLElement,
+      startX: event.clientX,
+      startY: event.clientY,
+      lastX: event.clientX,
+      lastY: event.clientY,
+      timer: window.setTimeout(lift, LIFT_MS),
+      lifted: false,
+      raf: 0,
+    };
+  };
+
+  const onBarPointerMove = (event: ReactPointerEvent) => {
+    const p = press.current;
+    if (!p || event.pointerId !== p.pointerId) return;
+    p.lastX = event.clientX;
+    p.lastY = event.clientY;
+    if (!p.lifted) {
+      if (Math.hypot(p.lastX - p.startX, p.lastY - p.startY) > SLOP_PX) clearPress();
+      return;
+    }
+    event.preventDefault();
+    hitTest();
+  };
+
+  const onBarPointerUp = (event: ReactPointerEvent) => {
+    const p = press.current;
+    if (!p || event.pointerId !== p.pointerId) return;
+    const wasLifted = p.lifted;
+    clearPress();
+    if (wasLifted) props.onDropOnKey(props.secKey);
+  };
+
+  const onBarPointerCancel = () => {
+    const p = press.current;
+    if (!p) return;
+    const wasLifted = p.lifted;
+    clearPress();
+    if (wasLifted) props.onDragEndKey();
+  };
+
   return (
     <div
       ref={ref}
-      className={props.dragging ? `${styles.card} ${styles.cardDragging}` : styles.card}
+      className={[
+        styles.card,
+        props.dragging && !lifted ? styles.cardDragging : undefined,
+        lifted ? styles.cardLifted : undefined,
+      ]
+        .filter(Boolean)
+        .join(' ')}
       data-sec={props.secKey}
       style={{
         order: props.order,
@@ -117,6 +253,9 @@ export function PlanCard(props: PlanCardProps) {
         title="Toggle width (1 or 2 panels)"
         aria-label={`Toggle width of ${props.title}`}
         aria-pressed={props.wide}
+        // Pointless on single-column layouts (phones) — hidden, not removed,
+        // so the control row keeps its geometry when the grid widens again.
+        style={props.canWide ? undefined : { display: 'none' }}
         onClick={props.onToggleWide}
       >
         <svg
@@ -156,7 +295,16 @@ export function PlanCard(props: PlanCardProps) {
           <path d="M19 5L5 19" />
         </svg>
       </button>
-      <div className={styles.secbar}>
+      <div
+        className={styles.secbar}
+        onPointerDown={onBarPointerDown}
+        onPointerMove={onBarPointerMove}
+        onPointerUp={onBarPointerUp}
+        onPointerCancel={onBarPointerCancel}
+        onContextMenu={(event) => {
+          if (press.current) event.preventDefault();
+        }}
+      >
         <span>{props.title}</span>
         {props.badge !== undefined && <span className={styles.secbarBadge}>{props.badge}</span>}
       </div>

--- a/apps/web/src/features/daily-plan/daily-plan-jump.test.tsx
+++ b/apps/web/src/features/daily-plan/daily-plan-jump.test.tsx
@@ -111,8 +111,8 @@ describe('Daily Plan jump navigation', () => {
         const raw = window.localStorage.getItem('daily_plan_settings');
         expect(raw).not.toBeNull();
         const order = JSON.parse(raw as string).secOrder as string[];
-        // focus keeps its hidden slot; gratitude and schedule swapped.
-        expect(order.slice(0, 3)).toEqual(['gratitude', 'focus', 'schedule']);
+        // focus keeps its hidden slot; priorities and schedule swapped.
+        expect(order.slice(0, 3)).toEqual(['priorities', 'focus', 'schedule']);
       },
       { timeout: 3000 },
     );

--- a/apps/web/src/features/daily-plan/lib/plan-model.ts
+++ b/apps/web/src/features/daily-plan/lib/plan-model.ts
@@ -27,19 +27,23 @@ export const PLAN_SECTIONS = [
 ] as const;
 export type PlanSectionKey = (typeof PLAN_SECTIONS)[number][0];
 
+// Default order is FUNCTIONAL-FIRST: the cards acted on all day (schedule,
+// focus, priorities, tasks, habits, workout, water, weight, tomorrow) lead;
+// the reflective ones (gratitude, mood, review, week) close the page. Users
+// override freely via secOrder — this only shapes brand-new accounts.
 export const PLAN_GRID_KEYS: PlanSectionKey[] = [
   'schedule',
   'focus',
-  'gratitude',
-  'mood',
   'priorities',
+  'todo',
   'habits',
   'workout',
-  'review',
-  'todo',
   'water',
   'weight',
   'tomorrow',
+  'gratitude',
+  'mood',
+  'review',
   'week',
 ];
 


### PR DESCRIPTION
## Summary

Round 2 of the Daily Plan phone pass, from on-device feedback (screenshots showed broken ✕ controls and no way to reorder cards by touch):

- **Fixed the broken card controls on touch devices** — the `@media (pointer: coarse)` hit-slop rule set `.cardCtl { position: relative }`, overriding their `position: absolute` and dumping the grip/width/✕ trio into a broken in-flow strip above every section bar. They now overlay the header as designed, and the width toggle hides on single-column layouts where span-2 is meaningless.
- **Touch reorder on the plan itself** — the section bar is now a hold-to-lift drag handle (350ms hold, a scroll cancels it; haptic tick where supported). It drives the grid's existing live-preview/commit drag wiring, and the viewport auto-scrolls near its edges so far-away slots are reachable. Desktop HTML5 grip drag and keyboard arrows unchanged.
- **Functional-first default order** — schedule, focus, priorities, to-do, habits, workout, water, weight, tomorrow lead; reflective cards (gratitude, mood, review, week) close the page. **Meals & Nutrition renders full-width directly under the masthead.** The jump sheet mirrors the page order (meals first, non-negotiables last). Existing `secOrder` customizations are untouched.
- **Pill glide-jump** — holding the jump pill (~250ms) opens the sheet under the still-held finger; sliding highlights the tile under the finger and releasing jumps there, one continuous gesture. Tap-to-open and tap-to-jump behave exactly as before.

**Verified end-to-end** with Playwright on a touch phone context (390×844) against the dev server in guest mode: meals renders above the grid in the new default order; the ✕ sits inside the card header (no strip); long-pressing a section bar lifts the card, live-reorders, and persists `secOrder` through the debounced save; holding the pill opens the sheet, gliding highlights tiles, and releasing on Water Tracker jumps to it and closes the sheet.

## Change Type
- [ ] Product behavior
- [ ] Feature scope
- [x] Frontend behavior
- [ ] Backend behavior
- [ ] API contract
- [ ] Data model
- [ ] Architecture
- [ ] Operations / deployment

## Documentation Impact
- [x] I evaluated documentation impact.
- [ ] I updated the relevant docs.
- [x] No docs update was needed, and I explained why below.

## Docs Updated

None.

## If no docs were updated, explain why

UI-only change inside the existing Daily Plan feature — no API, schema, or settings-contract changes (`PLAN_GRID_KEYS` keys are unchanged; only their default order moved, which the persisted `secOrder` mechanism already tolerates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV)_