### PR TITLE
feat(plan): schedule opens on the current hour with a live now-band

### DIFF
--- a/apps/web/src/features/daily-plan/DailyPlan.module.css
+++ b/apps/web/src/features/daily-plan/DailyPlan.module.css
@@ -799,6 +799,21 @@ button.weekChipToday:hover:not(:disabled) {
   font-variant-numeric: tabular-nums;
 }
 
+/* The hour you're living right now (today only) — same today-band language
+   as the habits grid, and the list opens scrolled to it. */
+.schedRowNow {
+  background: var(--plan-today-band);
+  box-shadow: var(--plan-today-shadow);
+  border-radius: 6px;
+  margin-inline: -6px;
+  padding-inline: 6px;
+}
+
+.schedRowNow .schedTime {
+  color: var(--plan-primary);
+  font-weight: 800;
+}
+
 /* ── priorities ──────────────────────────────────────────────────────────── */
 
 .prioNum {

--- a/apps/web/src/features/daily-plan/DailyPlanView.tsx
+++ b/apps/web/src/features/daily-plan/DailyPlanView.tsx
@@ -661,6 +661,7 @@ export function DailyPlanView({
           onOpenTask={(todo) => setPreviewId(todo.id)}
           onAddTaskAt={(hour) => openComposer(dateStr, hour)}
           onToggleSubtask={toggleSubtask}
+          isToday={isToday}
         />
       ),
     },

--- a/apps/web/src/features/daily-plan/cards.tsx
+++ b/apps/web/src/features/daily-plan/cards.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { CSSProperties, KeyboardEvent } from 'react';
 import type {
   DailyPlanData,
@@ -219,6 +219,8 @@ export interface ScheduleBodyProps {
   onOpenTask: (todo: Todo) => void;
   onAddTaskAt: (hour: string) => void;
   onToggleSubtask?: SubtaskToggle | undefined;
+  /** Viewing TODAY: the current hour gets a live band and the list opens on it. */
+  isToday?: boolean;
 }
 
 function SchedChip(props: {
@@ -287,6 +289,7 @@ export function ScheduleBody({
   onOpenTask,
   onAddTaskAt,
   onToggleSubtask,
+  isToday = false,
 }: ScheduleBodyProps) {
   const hours = scheduleHours(startHour, endHour);
   const byTime = (a: Todo, b: Todo) => (a.dueTime ?? '').localeCompare(b.dueTime ?? '');
@@ -297,19 +300,49 @@ export function ScheduleBody({
         t.dueTime !== null && !new Set(hours.map((h) => h.slice(0, 3))).has(t.dueTime.slice(0, 3)),
     )
     .sort(byTime);
+
+  // Live "now" band (today only): the hour is read fresh each render; a
+  // minute tick forces a render so the band crosses hour boundaries while
+  // the tab stays open.
+  const [, setNowTick] = useState(0);
+  useEffect(() => {
+    if (!isToday) return;
+    const timer = setInterval(() => setNowTick((t) => t + 1), 60_000);
+    return () => clearInterval(timer);
+  }, [isToday]);
+  const nowHour = new Date().getHours();
+  const nowLabel = isToday ? `${nowHour < 10 ? '0' : ''}${nowHour}:00` : null;
+
+  // Open on "now": today's list starts scrolled so the current hour sits a
+  // third of the way down its window instead of at 04:00.
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const nowRef = useRef<HTMLDivElement | null>(null);
+  useLayoutEffect(() => {
+    const list = listRef.current;
+    const row = nowRef.current;
+    if (!isToday || !list || !row) return;
+    list.scrollTop = Math.max(0, row.offsetTop - list.offsetTop - list.clientHeight / 3);
+  }, [isToday]);
+
   return (
     <div className={styles.cardBody}>
       {/* The full day of hour rows scrolls inside the card on phones. */}
-      <div className={`${styles.scrollList} ${styles.scrollTall}`}>
+      <div ref={listRef} className={`${styles.scrollList} ${styles.scrollTall}`}>
         {hours.map((time) => {
           const suggestions = suggestionsFor(time);
           // '13:30' lands on the '13:00' row; the chip shows the real minutes.
           const rowTodos = todos
             .filter((t) => t.dueTime?.startsWith(time.slice(0, 3)))
             .sort(byTime);
+          const isNow = time === nowLabel;
           return (
-            <div key={time}>
-              <div className={`${styles.rowRule} ${styles.schedRow}`}>
+            <div key={time} ref={isNow ? nowRef : undefined}>
+              <div
+                className={[styles.rowRule, styles.schedRow, isNow ? styles.schedRowNow : undefined]
+                  .filter(Boolean)
+                  .join(' ')}
+                {...(isNow ? { 'data-now': '' } : {})}
+              >
                 <span className={styles.schedTime}>{time}</span>
                 <input
                   dir="auto"

--- a/apps/web/src/features/daily-plan/daily-plan-view.test.tsx
+++ b/apps/web/src/features/daily-plan/daily-plan-view.test.tsx
@@ -86,6 +86,27 @@ describe('DailyPlanView', () => {
     expect(onSelectDay).toHaveBeenCalledTimes(1);
   });
 
+  it("today's schedule bands the current hour; other days don't", async () => {
+    renderPlan('today');
+    await screen.findByText('Schedule');
+    const hour = new Date().getHours();
+    const nowRow = document.querySelector('[data-now]');
+    if (hour >= 4 || hour === 0) {
+      // Default day runs 04:00 → 00:00 (24 renders as the 00:00 row).
+      expect(nowRow).not.toBeNull();
+      expect(nowRow?.textContent).toContain(`${hour < 10 ? '0' : ''}${hour}:00`);
+    } else {
+      // 01:00–03:00 sit outside the default hours — nothing to band.
+      expect(nowRow).toBeNull();
+    }
+  });
+
+  it('a past day never shows the now band', async () => {
+    renderPlan('2026-07-09');
+    await screen.findByText('Schedule');
+    expect(document.querySelector('[data-now]')).toBeNull();
+  });
+
   it('hiding a card moves it to the restore bar; Show all brings it back', async () => {
     const user = userEvent.setup();
     renderPlan();


### PR DESCRIPTION
## Summary

When viewing **today**, the Schedule card now meets you at the current hour instead of the day's first hour:

- The row for the hour you're in gets the plan's today-band treatment (band + subtle primary ring, primary-colored bold time) — same visual language as the habits grid's today column, driven by the phone's local clock.
- The card's internal scroll list opens with that row a third of the way down its window, so "now" is immediately visible without scrolling from 04:00.
- A minute tick keeps the band moving across hour boundaries while the tab stays open; hours outside the configured day (e.g. 02:00 on a 04:00→00:00 day) simply show no band.
- Other days render exactly as before — no band, list starts at the top.

**Verified in-browser** (phone viewport, guest mode): at the real clock the current hour is banded and in view; with the clock pinned to 20:14 the list opens scrolled (scrollTop 99) with `20:00` banded inside the window.

## Change Type
- [ ] Product behavior
- [ ] Feature scope
- [x] Frontend behavior
- [ ] Backend behavior
- [ ] API contract
- [ ] Data model
- [ ] Architecture
- [ ] Operations / deployment

## Documentation Impact
- [x] I evaluated documentation impact.
- [ ] I updated the relevant docs.
- [x] No docs update was needed, and I explained why below.

## Docs Updated

None.

## If no docs were updated, explain why

UI-only refinement of the existing Schedule card; no API, schema, or settings changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV)_