### PR TITLE
feat(web): new defaults — paper theme, plan-first home, compact-only, meals-led layout

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="dark">
+<html lang="en" data-theme="paper">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />

--- a/apps/web/src/app/app.test.tsx
+++ b/apps/web/src/app/app.test.tsx
@@ -8,6 +8,8 @@ describe('App smoke (local auth adapter + mocked /me)', () => {
   beforeEach(() => {
     vi.stubEnv('VITE_AUTH_DISABLED', '1');
     window.localStorage.clear();
+    // The shell smoke exercises Tasks mode; the home view now defaults to the plan.
+    window.localStorage.setItem('homeViewMode', 'tasks');
     window.history.replaceState(null, '', '/');
     queryClient.clear();
   });

--- a/apps/web/src/app/pages/dashboard.test.tsx
+++ b/apps/web/src/app/pages/dashboard.test.tsx
@@ -23,6 +23,8 @@ function renderDashboard(path = '/') {
 
 beforeEach(() => {
   window.localStorage.clear();
+  // These specs exercise Tasks mode; the home view now defaults to the plan.
+  window.localStorage.setItem('homeViewMode', 'tasks');
 });
 
 describe('DashboardPage day view', () => {

--- a/apps/web/src/app/providers/theme-provider.test.tsx
+++ b/apps/web/src/app/providers/theme-provider.test.tsx
@@ -57,10 +57,10 @@ describe('ThemeProvider', () => {
     vi.unstubAllGlobals();
   });
 
-  it('defaults to dark / DM Sans / 14 and applies the data-theme attribute', async () => {
+  it('defaults to paper / DM Sans / 14 and applies the data-theme attribute', async () => {
     renderThemed();
     await identityResolved();
-    expect(document.documentElement.dataset.theme).toBe('dark');
+    expect(document.documentElement.dataset.theme).toBe('paper');
     expect(screen.getByTestId('font').textContent).toBe('DM Sans');
     expect(screen.getByTestId('font-size').textContent).toBe('14');
     expect(document.documentElement.style.getPropertyValue('--font-family-base')).toContain(

--- a/apps/web/src/app/providers/theme-provider.tsx
+++ b/apps/web/src/app/providers/theme-provider.tsx
@@ -17,7 +17,7 @@ import type { FontName, ThemeContextValue, ThemeId } from './theme-context';
 
 /**
  * Theme/font state, ported from the old ThemeProvider:
- * - localStorage keys 'theme' / 'font' (defaults: 'dark', 'DM Sans');
+ * - localStorage keys 'theme' / 'font' (defaults: 'paper', 'DM Sans');
  * - applies documentElement[data-theme] and the --font-family-base inline var;
  * - fontSize (12–20, default 14) applies --font-size-base — the old Settings
  *   slider had no onChange, it is functional now;
@@ -36,9 +36,9 @@ function clampFontSize(value: number): number {
 function readStoredTheme(): ThemeId {
   try {
     const stored = window.localStorage.getItem(THEME_KEY);
-    return isThemeId(stored) ? stored : 'dark';
+    return isThemeId(stored) ? stored : 'paper';
   } catch {
-    return 'dark';
+    return 'paper';
   }
 }
 

--- a/apps/web/src/features/daily-plan/DailyPlan.module.css
+++ b/apps/web/src/features/daily-plan/DailyPlan.module.css
@@ -87,13 +87,6 @@
   padding-bottom: calc(56px + env(safe-area-inset-bottom, 0px));
 }
 
-.planRoot[data-density='roomy'] {
-  --colw: 420px;
-  --pad: 20px;
-  --gap: 20px;
-  --fs: 14px;
-}
-
 /* Paper = the print planner: serif display everywhere, italic serif prompts. */
 :global([data-theme='paper']) .planRoot .prompt,
 :global([data-theme='paper']) .planRoot .mastheadSub {

--- a/apps/web/src/features/daily-plan/DailyPlanView.tsx
+++ b/apps/web/src/features/daily-plan/DailyPlanView.tsx
@@ -321,9 +321,10 @@ export function DailyPlanView({
   const [draggingKey, setDraggingKey] = useState<string | null>(null);
   const order = previewOrder ?? persistedOrder;
 
-  const density = settings.density;
-  const colw = density === 'roomy' ? 420 : 340;
-  const gap = density === 'roomy' ? 20 : 14;
+  // Compact is THE density — the roomy variant and its toggle are retired
+  // (settings.density still parses for old blobs; it is simply ignored).
+  const colw = 340;
+  const gap = 14;
 
   // span-2 is only legal when the grid actually fits two columns.
   const gridRef = useRef<HTMLDivElement | null>(null);
@@ -831,7 +832,7 @@ export function DailyPlanView({
   const densityStyle = { '--colw': `${colw}px` } as CSSProperties;
 
   return (
-    <div className={styles.planRoot} data-density={density} style={densityStyle}>
+    <div className={styles.planRoot} data-density="compact" style={densityStyle}>
       <div
         style={{
           display: 'flex',
@@ -852,15 +853,6 @@ export function DailyPlanView({
           // active (the old ternary showed DARK as selected on all of them).
           value={theme === 'paper' || theme === 'dark' ? theme : ''}
           onChange={(value) => setTheme(value === 'paper' ? 'paper' : 'dark')}
-        />
-        <Segmented
-          label="Density"
-          options={[
-            ['compact', 'COMPACT'],
-            ['roomy', 'ROOMY'],
-          ]}
-          value={density}
-          onChange={(value) => patchSettings({ density: value as 'compact' | 'roomy' })}
         />
         <button
           type="button"

--- a/apps/web/src/features/daily-plan/daily-plan-jump.test.tsx
+++ b/apps/web/src/features/daily-plan/daily-plan-jump.test.tsx
@@ -87,7 +87,7 @@ describe('Daily Plan jump navigation', () => {
         const raw = window.localStorage.getItem('daily_plan_settings');
         expect(raw).not.toBeNull();
         const order = JSON.parse(raw as string).secOrder as string[];
-        expect(order.indexOf('focus')).toBe(0);
+        expect(order.indexOf('habits')).toBe(0);
         expect(order.indexOf('schedule')).toBe(1);
       },
       { timeout: 3000 },
@@ -97,8 +97,8 @@ describe('Daily Plan jump navigation', () => {
   it('reordering from the sheet keeps hidden cards parked in their slot', async () => {
     const user = userEvent.setup();
     renderPlan();
-    // Hide the second card (Focus Zone), then move Schedule one slot later —
-    // it must hop over the hidden card's parked slot.
+    // Hide Focus Zone (third by default), then move Schedule one slot later —
+    // the hidden card must keep its parked slot through the merge.
     await user.click(await screen.findByRole('button', { name: 'Hide Focus Zone' }));
 
     const sheet = await openSheet(user);
@@ -111,8 +111,8 @@ describe('Daily Plan jump navigation', () => {
         const raw = window.localStorage.getItem('daily_plan_settings');
         expect(raw).not.toBeNull();
         const order = JSON.parse(raw as string).secOrder as string[];
-        // focus keeps its hidden slot; priorities and schedule swapped.
-        expect(order.slice(0, 3)).toEqual(['priorities', 'focus', 'schedule']);
+        // focus keeps its hidden slot; habits and schedule swapped ahead of it.
+        expect(order.slice(0, 3)).toEqual(['habits', 'schedule', 'focus']);
       },
       { timeout: 3000 },
     );

--- a/apps/web/src/features/daily-plan/daily-plan-polish.test.tsx
+++ b/apps/web/src/features/daily-plan/daily-plan-polish.test.tsx
@@ -38,7 +38,7 @@ describe('card reorder via keyboard', () => {
         const raw = window.localStorage.getItem('daily_plan_settings');
         expect(raw).not.toBeNull();
         const { secOrder } = JSON.parse(raw as string) as { secOrder: string[] };
-        expect(secOrder[0]).toBe('focus');
+        expect(secOrder[0]).toBe('habits');
         expect(secOrder[1]).toBe('schedule');
       },
       { timeout: 3000 },

--- a/apps/web/src/features/daily-plan/data/view-mode.ts
+++ b/apps/web/src/features/daily-plan/data/view-mode.ts
@@ -18,9 +18,10 @@ function isHomeViewMode(value: unknown): value is HomeViewMode {
 function readStoredMode(): HomeViewMode {
   try {
     const raw = window.localStorage.getItem(MODE_KEY);
-    return isHomeViewMode(raw) ? raw : 'tasks';
+    // The Daily Plan IS the home page — Tasks mode only when chosen.
+    return isHomeViewMode(raw) ? raw : 'plan';
   } catch {
-    return 'tasks';
+    return 'plan';
   }
 }
 

--- a/apps/web/src/features/daily-plan/lib/plan-model.ts
+++ b/apps/web/src/features/daily-plan/lib/plan-model.ts
@@ -27,17 +27,18 @@ export const PLAN_SECTIONS = [
 ] as const;
 export type PlanSectionKey = (typeof PLAN_SECTIONS)[number][0];
 
-// Default order is FUNCTIONAL-FIRST: the cards acted on all day (schedule,
-// focus, priorities, tasks, habits, workout, water, weight, tomorrow) lead;
-// the reflective ones (gratitude, mood, review, week) close the page. Users
-// override freely via secOrder — this only shapes brand-new accounts.
+// Default order is FUNCTIONAL-FIRST: the cards acted on all day lead —
+// schedule, habits, focus, priorities, workout (meals renders full-width
+// above the grid) — and the reflective ones (gratitude, mood, review, week)
+// close the page. Users override freely via secOrder — this only shapes
+// accounts that never rearranged.
 export const PLAN_GRID_KEYS: PlanSectionKey[] = [
   'schedule',
+  'habits',
   'focus',
   'priorities',
-  'todo',
-  'habits',
   'workout',
+  'todo',
   'water',
   'weight',
   'tomorrow',


### PR DESCRIPTION
## Summary

Product-defaults round for the Daily Plan experience:

- **Paper is the default theme** — `index.html` boots with `data-theme="paper"` and the theme provider falls back to paper when nothing is stored. Users (or devices) with an explicitly chosen theme keep their choice.
- **The Daily Plan is the home view** — `homeViewMode` defaults to `plan`; Tasks mode only appears when the user switches to it (and their choice still persists).
- **Compact is the only density** — the ROOMY option and the whole COMPACT/ROOMY toggle are removed from the plan toolbar; the view hardcodes compact metrics. Stored `density: 'roomy'` blobs still parse (schema untouched) and are simply ignored.
- **Default card layout** — Meals & Nutrition full-width up top, then Schedule, Daily Habits, Focus, Top 3 Priorities, Workout, then the remaining functional cards, with the reflective ones (Gratitude, Mood, Evening Review, Week Review) closing the page. Persisted `secOrder` customizations are untouched — this shapes accounts that never rearranged.

**Verified in-browser** with a completely fresh visitor context (no storage): lands on the paper-themed Daily Plan, meals→schedule→habits→focus→priorities→workout order, no density toggle. Full web suite (239 tests) green; affected specs (theme default, tasks-mode dashboard smoke, reorder order expectations) updated to pin or reflect the new defaults.

## Change Type
- [x] Product behavior
- [ ] Feature scope
- [x] Frontend behavior
- [ ] Backend behavior
- [ ] API contract
- [ ] Data model
- [ ] Architecture
- [ ] Operations / deployment

## Documentation Impact
- [x] I evaluated documentation impact.
- [ ] I updated the relevant docs.
- [x] No docs update was needed, and I explained why below.

## Docs Updated

None.

## If no docs were updated, explain why

Defaults-only change: no API, schema, or contract changes — stored preferences (`theme`, `homeViewMode`, `secOrder`, `density`) keep their formats and continue to win over the new defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV)_