### PR TITLE
feat(plan): close button on the Add Task popup

### DIFF
--- a/apps/web/src/features/daily-plan/ComposerModal.module.css
+++ b/apps/web/src/features/daily-plan/ComposerModal.module.css
@@ -26,5 +26,60 @@
   width: min(680px, 100%);
   max-height: 100dvh;
   overflow-y: auto;
-  padding: var(--space-24) var(--space-16) calc(var(--space-24) + env(safe-area-inset-bottom, 0px));
+  padding: var(--space-12) var(--space-16) calc(var(--space-24) + env(safe-area-inset-bottom, 0px));
+}
+
+/* Cancel affordance: rides sticky at the top of the scrolling sheet so it
+   never scrolls out of thumb reach (Escape needs a keyboard; the scrim is a
+   sliver on phones). */
+.closeRow {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  justify-content: flex-end;
+  padding: var(--space-4) 0;
+}
+
+.close {
+  position: relative;
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+  transition:
+    color var(--transition-fast),
+    border-color var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.close:hover,
+.close:focus-visible {
+  color: var(--color-text);
+  border-color: var(--color-text-muted);
+}
+
+.close:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.close:active {
+  transform: scale(0.92);
+}
+
+/* Touch hit-slop beyond the visible circle. */
+@media (pointer: coarse) {
+  .close::after {
+    content: '';
+    position: absolute;
+    inset: -8px;
+  }
 }

--- a/apps/web/src/features/daily-plan/ComposerModal.tsx
+++ b/apps/web/src/features/daily-plan/ComposerModal.tsx
@@ -55,6 +55,25 @@ export function ComposerModal({
       }}
     >
       <div className={styles.sheet} role="dialog" aria-modal="true" aria-label="Add task">
+        {/* The sheet can outgrow a phone screen and Escape needs a keyboard —
+            a sticky ✕ keeps cancel one thumb-tap away at any scroll depth. */}
+        <div className={styles.closeRow}>
+          <button type="button" className={styles.close} aria-label="Close" onClick={onClose}>
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.4"
+              strokeLinecap="round"
+              aria-hidden="true"
+            >
+              <path d="M5 5l14 14" />
+              <path d="M19 5L5 19" />
+            </svg>
+          </button>
+        </div>
         <Composer
           open={open}
           allTags={allTags}

--- a/apps/web/src/features/daily-plan/daily-plan-tasks.test.tsx
+++ b/apps/web/src/features/daily-plan/daily-plan-tasks.test.tsx
@@ -119,6 +119,23 @@ describe('Schedule card', () => {
       });
     });
   });
+
+  it('the ✕ closes the Add Task popup and keeps the draft for the next open', async () => {
+    const user = userEvent.setup();
+    renderPlan([]);
+
+    await user.click(await screen.findByLabelText('Add task at 05:00'));
+    const dialog = await screen.findByRole('dialog', { name: 'Add task' });
+    await user.type(within(dialog).getByLabelText('Task title'), 'Cold shower');
+
+    await user.click(within(dialog).getByRole('button', { name: 'Close' }));
+    expect(screen.queryByRole('dialog', { name: 'Add task' })).not.toBeInTheDocument();
+
+    // Accidental dismiss must not eat the draft (the sheet stays mounted).
+    await user.click(await screen.findByLabelText('Add task at 05:00'));
+    const reopened = await screen.findByRole('dialog', { name: 'Add task' });
+    expect(within(reopened).getByLabelText('Task title')).toHaveValue('Cold shower');
+  });
 });
 
 describe('Tomorrow card', () => {


### PR DESCRIPTION
## Summary

On phones the Add Task composer fills the whole screen, Escape needs a keyboard, and the click-outside scrim is a sliver — so there was effectively no visible way to cancel (user-reported with a screenshot).

- Adds a circular ✕ to the composer sheet, riding **sticky at the top-right of the scrolling sheet** so it stays one thumb-tap away at any scroll depth, with pointer-coarse hit-slop, hover/active/focus-visible states, and `aria-label="Close"`.
- Dismissing via ✕ keeps the draft — the sheet stays mounted between opens, matching the existing accidental-dismiss design — covered by a new regression test (close, reopen, title still there).

**Verified in-browser** (390×844 touch viewport, guest mode): ✕ visible on open, still pinned on-screen after scrolling the sheet 400px, click closes the dialog.

## Change Type
- [ ] Product behavior
- [ ] Feature scope
- [x] Frontend behavior
- [ ] Backend behavior
- [ ] API contract
- [ ] Data model
- [ ] Architecture
- [ ] Operations / deployment

## Documentation Impact
- [x] I evaluated documentation impact.
- [ ] I updated the relevant docs.
- [x] No docs update was needed, and I explained why below.

## Docs Updated

None.

## If no docs were updated, explain why

Small UI affordance inside the existing composer popup; no API or contract surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV)_