### PR TITLE
fix(plan): stop long-press text selection during jump/drag gestures

### DIFF
--- a/apps/web/src/features/daily-plan/JumpSheet.module.css
+++ b/apps/web/src/features/daily-plan/JumpSheet.module.css
@@ -135,6 +135,11 @@
   box-shadow: 0 -12px 48px rgba(0, 0, 0, 0.35);
   padding: 6px 14px calc(14px + env(safe-area-inset-bottom, 0px));
   animation: sheetIn 0.3s cubic-bezier(0.32, 0.72, 0.22, 1);
+  /* Nothing in the sheet is copy-worthy, and any selectable text in here is
+     a target for WebKit's long-press selection creep during drags. */
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
 }
 
 .sheet:not([data-open]) {

--- a/apps/web/src/features/daily-plan/JumpSheet.tsx
+++ b/apps/web/src/features/daily-plan/JumpSheet.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent as ReactPointerEvent } from 'react';
 import { createPortal } from 'react-dom';
+import { clearTextSelection, suppressTextSelection } from './lib/gesture-select';
 import styles from './JumpSheet.module.css';
 
 /**
@@ -161,6 +162,7 @@ export function JumpSheet({ sections, onReorder }: JumpSheetProps) {
     const d = drag.current;
     if (!d) return;
     if (d.timer !== null) window.clearTimeout(d.timer);
+    suppressTextSelection(false);
     document.removeEventListener('touchmove', preventTouchScroll);
     if (d.lifted) {
       try {
@@ -206,12 +208,13 @@ export function JumpSheet({ sections, onReorder }: JumpSheetProps) {
   }, [open]);
 
   // Global teardown for an in-flight drag or pill glide (unmount mid-gesture
-  // must not leave a non-passive touchmove blocker behind).
+  // must not leave a non-passive touchmove blocker or selection guard behind).
   useEffect(
     () => () => {
       if (drag.current?.timer != null) window.clearTimeout(drag.current.timer);
       if (glide.current?.timer != null) window.clearTimeout(glide.current.timer);
       document.removeEventListener('touchmove', preventTouchScroll);
+      suppressTextSelection(false);
     },
     [],
   );
@@ -237,6 +240,7 @@ export function JumpSheet({ sections, onReorder }: JumpSheetProps) {
     const g = glide.current;
     if (!g) return;
     if (g.timer !== null) window.clearTimeout(g.timer);
+    suppressTextSelection(false);
     if (g.active) {
       document.removeEventListener('touchmove', preventTouchScroll);
       try {
@@ -262,12 +266,14 @@ export function JumpSheet({ sections, onReorder }: JumpSheetProps) {
     // Same claim as the tile lift: the finger is stationary, no scroll owns
     // the touch — block panning so the glide tracks cleanly.
     document.addEventListener('touchmove', preventTouchScroll, { passive: false });
+    clearTextSelection();
     navigator.vibrate?.(10);
     openSheet();
   };
 
   const onPillPointerDown = (event: ReactPointerEvent) => {
     if (event.button !== 0) return;
+    suppressTextSelection(true);
     glide.current = {
       pointerId: event.pointerId,
       startX: event.clientX,
@@ -316,6 +322,7 @@ export function JumpSheet({ sections, onReorder }: JumpSheetProps) {
     // The finger is stationary past the hold delay, so no scroll owns this
     // touch yet — claim it, or the first drag movement scrolls the sheet.
     document.addEventListener('touchmove', preventTouchScroll, { passive: false });
+    clearTextSelection();
     navigator.vibrate?.(10);
     setLiftedKey(d.key);
     applyLiftTransform(d);
@@ -323,6 +330,7 @@ export function JumpSheet({ sections, onReorder }: JumpSheetProps) {
 
   const onTilePointerDown = (event: ReactPointerEvent, key: string) => {
     if (byKey.get(key)?.fixed || event.button !== 0) return;
+    suppressTextSelection(true);
     const el = event.currentTarget as HTMLElement;
     drag.current = {
       key,

--- a/apps/web/src/features/daily-plan/PlanCard.tsx
+++ b/apps/web/src/features/daily-plan/PlanCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { DragEvent, PointerEvent as ReactPointerEvent, ReactNode } from 'react';
+import { clearTextSelection, suppressTextSelection } from './lib/gesture-select';
 import { masonryRowSpan } from './lib/masonry';
 import styles from './DailyPlan.module.css';
 
@@ -109,6 +110,7 @@ export function PlanCard(props: PlanCardProps) {
     if (!p) return;
     if (p.timer !== null) window.clearTimeout(p.timer);
     cancelAnimationFrame(p.raf);
+    suppressTextSelection(false);
     document.removeEventListener('touchmove', preventTouchScroll);
     if (p.lifted) {
       try {
@@ -136,6 +138,7 @@ export function PlanCard(props: PlanCardProps) {
     // Finger held still past the delay — no scroll owns this touch yet, so
     // claim it before the first drag movement pans the page instead.
     document.addEventListener('touchmove', preventTouchScroll, { passive: false });
+    clearTextSelection();
     navigator.vibrate?.(10);
     setLifted(true);
     props.onDragStartKey(props.secKey);
@@ -144,6 +147,7 @@ export function PlanCard(props: PlanCardProps) {
 
   const onBarPointerDown = (event: ReactPointerEvent) => {
     if (event.button !== 0) return;
+    suppressTextSelection(true);
     press.current = {
       pointerId: event.pointerId,
       el: event.currentTarget as HTMLElement,

--- a/apps/web/src/features/daily-plan/lib/gesture-select.ts
+++ b/apps/web/src/features/daily-plan/lib/gesture-select.ts
@@ -1,0 +1,23 @@
+/**
+ * Text-selection suppression for hold-to-drag gestures. Touch browsers
+ * (iOS Safari above all) start text selection on a long-press even when the
+ * pressed element is user-select:none — WebKit walks to the NEAREST
+ * selectable text ("selection creep") and grabs that, popping the magnifier
+ * and Copy callout mid-drag. While a gesture is pending we blanket-suppress
+ * selection with a body class (see globals.css), and on lift we clear
+ * whatever the OS managed to select before we claimed the touch.
+ */
+
+const CLASS = 'gesture-no-select';
+
+export function suppressTextSelection(on: boolean): void {
+  document.body.classList.toggle(CLASS, on);
+}
+
+export function clearTextSelection(): void {
+  try {
+    window.getSelection()?.removeAllRanges();
+  } catch {
+    /* selection API unavailable */
+  }
+}

--- a/apps/web/src/shared/styles/globals.css
+++ b/apps/web/src/shared/styles/globals.css
@@ -238,3 +238,16 @@ svg {
   padding-top: env(safe-area-inset-top);
   padding-bottom: env(safe-area-inset-bottom);
 }
+
+/* ── Gesture selection guard ───────────────────────────────────────────────
+   Applied to <body> while a hold-to-drag gesture is pending (jump pill,
+   sheet tiles, card section bars). Touch browsers otherwise start text
+   selection on long-press — WebKit even creeps to the NEAREST selectable
+   text when the pressed element itself is user-select:none. Scoped to the
+   gesture lifetime, so normal copy/paste everywhere is untouched. */
+body.gesture-no-select,
+body.gesture-no-select * {
+  user-select: none !important;
+  -webkit-user-select: none !important;
+  -webkit-touch-callout: none !important;
+}


### PR DESCRIPTION
## Summary

User-reported (with screenshots): holding the jump pill / sheet tiles on iPhone pops iOS text selection — magnifier, blue handles across the sheet's "↑ Top / ↓ Bottom" footer, and the Copy/Find Selection callout. Root cause is WebKit's *selection creep*: a long-press on a `user-select: none` element still starts selection on the **nearest selectable text**, and the sheet's header/footer text wasn't marked unselectable.

Three-layer fix, none of which affects normal copy/paste elsewhere in the app:

1. **The whole jump sheet is now `user-select: none`** (labels, statuses, header, footer) — nothing in it is copy-worthy, so there's no target for creep inside the sheet.
2. **A body-level `gesture-no-select` guard** (new `globals.css` utility + `lib/gesture-select.ts` helper) suppresses selection everywhere while a hold gesture is *pending* — on the pill, a sheet tile, or a card section bar — and lifts on release, cancel, or unmount. Selection is only ever suppressed for the duration of a press.
3. **`clearTextSelection()` at lift** — anything the OS managed to select before the hold threshold is wiped the moment the gesture engages.

**Verified in-browser** (phone viewport): every text node in the sheet computes `user-select: none`; the body guard class is present during a held press (tile and card bar) and gone after release; `window.getSelection()` stays empty through a hold.

## Change Type
- [ ] Product behavior
- [ ] Feature scope
- [x] Frontend behavior
- [ ] Backend behavior
- [ ] API contract
- [ ] Data model
- [ ] Architecture
- [ ] Operations / deployment

## Documentation Impact
- [x] I evaluated documentation impact.
- [ ] I updated the relevant docs.
- [x] No docs update was needed, and I explained why below.

## Docs Updated

None.

## If no docs were updated, explain why

Touch-interaction polish inside existing components; no API or contract surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV)_