### PR TITLE
feat(plan): readability pass + A−/A/A+ text-size control

### DIFF
--- a/apps/web/src/features/daily-plan/DailyPlan.module.css
+++ b/apps/web/src/features/daily-plan/DailyPlan.module.css
@@ -64,7 +64,9 @@
   --plan-hover: #e9e8e0;
   --plan-primary: #141414;
   --plan-primary-ink: #fff;
-  --plan-muted: #5c5c56;
+  /* Darker than the handoff's #5c5c56 — small muted text on the warm paper
+     ground needs the extra contrast to stay readable on phones. */
+  --plan-muted: #4e4e47;
   --plan-danger: #b91c1c;
   --plan-rad: 4px;
   --plan-today-band: rgba(20, 20, 20, 0.05);
@@ -80,7 +82,7 @@
   --gap: 14px;
   --fs: 13px;
 
-  font-size: var(--fs);
+  font-size: calc(var(--fs) * var(--plan-scale, 1));
   animation: fadeIn 0.3s ease-out;
   /* The floating jump pill hovers over the page bottom — keep the motto and
      last card reachable above it (plus phone home bars). */
@@ -126,7 +128,7 @@
 
 .mastheadTitle {
   font-family: var(--plan-display-font);
-  font-size: clamp(28px, 4.5vw, 40px);
+  font-size: calc(clamp(28px, 4.5vw, 40px) * var(--plan-scale, 1));
   font-weight: 800;
   letter-spacing: 0.04em;
   line-height: 1;
@@ -139,7 +141,7 @@
   margin-top: 8px;
   color: var(--plan-muted);
   letter-spacing: 0.22em;
-  font-size: 11px;
+  font-size: calc(11px * var(--plan-scale, 1));
   text-transform: uppercase;
 }
 
@@ -174,7 +176,7 @@
   border: 1px solid var(--plan-rule);
   background: transparent;
   color: var(--plan-muted);
-  font-size: 15px;
+  font-size: calc(15px * var(--plan-scale, 1));
   line-height: 1;
   display: inline-flex;
   align-items: center;
@@ -218,7 +220,7 @@
 
 .saveHint {
   align-self: center;
-  font-size: 11px;
+  font-size: calc(11px * var(--plan-scale, 1));
   letter-spacing: 0.06em;
   color: var(--plan-muted);
 }
@@ -240,7 +242,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 11px;
+  font-size: calc(11px * var(--plan-scale, 1));
   font-weight: 700;
   color: var(--plan-muted);
   border: 1px solid var(--plan-rule);
@@ -280,7 +282,7 @@ button.weekChipToday:hover:not(:disabled) {
 }
 
 .scoreLabel {
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   letter-spacing: 0.18em;
   color: var(--plan-muted);
   text-transform: uppercase;
@@ -303,7 +305,7 @@ button.weekChipToday:hover:not(:disabled) {
 }
 
 .hiddenBarLabel {
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--plan-muted);
@@ -318,7 +320,7 @@ button.weekChipToday:hover:not(:disabled) {
   padding: 4px 11px;
   border: 1px solid var(--plan-card-border);
   border-radius: 999px;
-  font-size: 11px;
+  font-size: calc(11px * var(--plan-scale, 1));
   font-weight: 600;
   color: var(--color-text);
   background: transparent;
@@ -332,7 +334,7 @@ button.weekChipToday:hover:not(:disabled) {
 
 .showAll {
   margin-left: auto;
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--plan-muted);
@@ -378,9 +380,13 @@ button.weekChipToday:hover:not(:disabled) {
   background: var(--plan-secbar);
   color: var(--plan-secbar-text);
   padding: 8px 14px;
-  font-family: var(--plan-display-font);
+  /* Label sans, NOT the display face: paper's display serif (Playfair) has
+     hairline strokes that turn to mud at 11px reversed on the ink band —
+     the quiet sans keeps the small-caps look and stays readable. Dark is
+     unchanged (its display and label faces are the same sans). */
+  font-family: var(--plan-label-font);
   font-weight: 700;
-  font-size: 11px;
+  font-size: calc(11px * var(--plan-scale, 1));
   letter-spacing: 0.16em;
   text-transform: uppercase;
   display: flex;
@@ -391,7 +397,7 @@ button.weekChipToday:hover:not(:disabled) {
 }
 
 .secbarBadge {
-  font-size: 9px;
+  font-size: calc(9px * var(--plan-scale, 1));
   letter-spacing: 0.1em;
   opacity: 0.75;
 }
@@ -664,8 +670,8 @@ button.weekChipToday:hover:not(:disabled) {
 }
 
 .square {
-  width: 17px;
-  height: 17px;
+  width: calc(17px * var(--plan-scale, 1));
+  height: calc(17px * var(--plan-scale, 1));
   flex: 0 0 auto;
   border-radius: 3px;
   padding: 0;
@@ -675,7 +681,7 @@ button.weekChipToday:hover:not(:disabled) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 11px;
+  font-size: calc(11px * var(--plan-scale, 1));
   font-weight: 800;
   line-height: 1;
   cursor: pointer;
@@ -692,7 +698,7 @@ button.weekChipToday:hover:not(:disabled) {
   border-radius: 999px;
   border: 1px solid var(--plan-card-border);
   color: var(--plan-muted);
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   font-weight: 600;
   flex: 0 0 auto;
 }
@@ -704,7 +710,7 @@ button.weekChipToday:hover:not(:disabled) {
   padding: 7px 13px;
   border: 1px solid var(--plan-card-border);
   border-radius: 999px;
-  font-size: 10.5px;
+  font-size: calc(10.5px * var(--plan-scale, 1));
   font-weight: 700;
   letter-spacing: 0.1em;
   color: var(--color-text);
@@ -723,7 +729,7 @@ button.weekChipToday:hover:not(:disabled) {
   border: 1px solid var(--plan-card-border);
   color: var(--color-text);
   font-weight: 600;
-  font-size: 11.5px;
+  font-size: calc(11.5px * var(--plan-scale, 1));
   background: transparent;
   cursor: pointer;
 }
@@ -741,7 +747,7 @@ button.weekChipToday:hover:not(:disabled) {
   background: var(--plan-primary);
   color: var(--plan-primary-ink);
   font-weight: 700;
-  font-size: 12px;
+  font-size: calc(12px * var(--plan-scale, 1));
   border: none;
   cursor: pointer;
 }
@@ -751,7 +757,7 @@ button.weekChipToday:hover:not(:disabled) {
   border: 1px solid var(--plan-card-border);
   border-radius: 8px;
   padding: 6px 10px;
-  font-size: 12px;
+  font-size: calc(12px * var(--plan-scale, 1));
   color: var(--color-text);
   font-family: inherit;
   min-width: 0;
@@ -763,7 +769,7 @@ button.weekChipToday:hover:not(:disabled) {
 }
 
 .sectionMini {
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   letter-spacing: 0.14em;
   text-transform: uppercase;
   font-weight: 700;
@@ -787,7 +793,7 @@ button.weekChipToday:hover:not(:disabled) {
   width: 40px;
   flex: 0 0 auto;
   color: var(--plan-muted);
-  font-size: 11px;
+  font-size: calc(11px * var(--plan-scale, 1));
   font-weight: 600;
   font-variant-numeric: tabular-nums;
 }
@@ -812,7 +818,7 @@ button.weekChipToday:hover:not(:disabled) {
 .prioNum {
   font-family: var(--plan-display-font);
   font-weight: 700;
-  font-size: 15px;
+  font-size: calc(15px * var(--plan-scale, 1));
   width: 18px;
   flex: 0 0 auto;
 }
@@ -850,7 +856,7 @@ button.weekChipToday:hover:not(:disabled) {
 
 .habitHead {
   text-align: center;
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   font-weight: 700;
   color: var(--plan-muted);
 }
@@ -899,7 +905,7 @@ button.weekChipToday:hover:not(:disabled) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 9px;
+  font-size: calc(9px * var(--plan-scale, 1));
   line-height: 1;
   padding: 0;
 }
@@ -930,7 +936,7 @@ button.weekChipToday:hover:not(:disabled) {
   padding: 0 4px;
   border-radius: 999px;
   border: 1px solid var(--plan-card-border);
-  font-size: 8.5px;
+  font-size: calc(8.5px * var(--plan-scale, 1));
   font-weight: 700;
   color: var(--plan-muted);
   font-variant-numeric: tabular-nums;
@@ -1032,7 +1038,7 @@ button.weekBarBtn:hover .weekBarFill {
   display: flex;
   flex-direction: column;
   gap: 3px;
-  font-size: 13px;
+  font-size: calc(13px * var(--plan-scale, 1));
   font-weight: 600;
   font-variant-numeric: tabular-nums;
 }
@@ -1065,7 +1071,7 @@ button.weekBarBtn:hover .weekBarFill {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-size: 9px;
+  font-size: calc(9px * var(--plan-scale, 1));
   color: var(--plan-muted);
   font-weight: 700;
   letter-spacing: 0.08em;
@@ -1095,7 +1101,7 @@ button.weekBarBtn:hover .weekBarFill {
 
 .todoSub {
   margin-left: auto;
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   color: var(--plan-muted);
   flex: 0 0 auto;
 }
@@ -1117,7 +1123,7 @@ button.weekBarBtn:hover .weekBarFill {
 }
 
 .tagMore {
-  font-size: 9px;
+  font-size: calc(9px * var(--plan-scale, 1));
   font-weight: 600;
   color: var(--plan-muted);
   font-variant-numeric: tabular-nums;
@@ -1157,19 +1163,19 @@ button.weekBarBtn:hover .weekBarFill {
 .addTaskBtn {
   composes: pillBtn;
   padding: 4px 10px;
-  font-size: 9.5px;
+  font-size: calc(9.5px * var(--plan-scale, 1));
 }
 
 .emptyHint {
   padding: 6px 0;
-  font-size: 12px;
+  font-size: calc(12px * var(--plan-scale, 1));
   color: var(--plan-muted);
   font-style: italic;
 }
 
 .quickError {
   padding-top: 4px;
-  font-size: 11.5px;
+  font-size: calc(11.5px * var(--plan-scale, 1));
   color: var(--color-danger, #c0392b);
 }
 
@@ -1182,7 +1188,7 @@ button.weekBarBtn:hover .weekBarFill {
   border: 1px solid var(--plan-card-border);
   background: transparent;
   color: var(--plan-muted);
-  font-size: 13px;
+  font-size: calc(13px * var(--plan-scale, 1));
   line-height: 1;
   cursor: pointer;
   opacity: 0;
@@ -1213,13 +1219,13 @@ button.weekBarBtn:hover .weekBarFill {
   gap: 8px;
   padding: 3px 0 3px 44px;
   border-bottom: 1px dashed var(--plan-rule);
-  font-size: 12px;
+  font-size: calc(12px * var(--plan-scale, 1));
 }
 
 .chipTime {
   margin-left: auto;
   flex: 0 0 auto;
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   color: var(--plan-muted);
   font-variant-numeric: tabular-nums;
 }
@@ -1236,7 +1242,7 @@ button.weekBarBtn:hover .weekBarFill {
   border-radius: 999px;
   background: transparent;
   color: var(--plan-muted);
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   font-weight: 600;
   font-variant-numeric: tabular-nums;
   cursor: pointer;
@@ -1263,14 +1269,14 @@ button.weekBarBtn:hover .weekBarFill {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 11.5px;
+  font-size: calc(11.5px * var(--plan-scale, 1));
   padding: 2px 0;
   color: var(--plan-muted);
 }
 
 /* A checked-off subtask reads as done without a heavy strike — lighter ink. */
 .subtaskRow .todoTitleDone {
-  font-size: 11.5px;
+  font-size: calc(11.5px * var(--plan-scale, 1));
 }
 
 .schedChipSubs {
@@ -1304,7 +1310,7 @@ button.weekBarBtn:hover .weekBarFill {
   composes: circle;
   width: 20px;
   height: 20px;
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   font-weight: 700;
   display: inline-flex;
   align-items: center;
@@ -1396,7 +1402,7 @@ button.weekBarBtn:hover .weekBarFill {
   border-radius: 999px;
   background: transparent;
   color: var(--plan-muted);
-  font-size: 11px;
+  font-size: calc(11px * var(--plan-scale, 1));
   letter-spacing: 0.04em;
   cursor: pointer;
 }
@@ -1442,7 +1448,7 @@ button.weekBarBtn:hover .weekBarFill {
 }
 
 .measureHead {
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--plan-muted);
@@ -1458,7 +1464,7 @@ button.weekBarBtn:hover .weekBarFill {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
+  font-size: calc(12px * var(--plan-scale, 1));
 }
 
 .measureLabel {
@@ -1472,7 +1478,7 @@ button.weekBarBtn:hover .weekBarFill {
   border-bottom: 1px solid var(--plan-rule);
   background: transparent;
   color: var(--color-text);
-  font-size: 13px;
+  font-size: calc(13px * var(--plan-scale, 1));
   text-align: right;
   font-variant-numeric: tabular-nums;
   padding: 1px 0;
@@ -1491,7 +1497,7 @@ button.weekBarBtn:hover .weekBarFill {
 
 .measureUnit {
   color: var(--plan-muted);
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   width: 2.4ch;
 }
 
@@ -1508,12 +1514,12 @@ button.weekBarBtn:hover .weekBarFill {
 .gymTitle {
   font-family: var(--plan-display-font);
   font-weight: 800;
-  font-size: 19px;
+  font-size: calc(19px * var(--plan-scale, 1));
   line-height: 1.1;
 }
 
 .gymSubtitle {
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   color: var(--plan-muted);
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -1542,7 +1548,7 @@ button.weekBarBtn:hover .weekBarFill {
 
 /* Quiet "N min cardio · ~X kcal burned" line under the workout exercises. */
 .cardioBurn {
-  font-size: 10.5px;
+  font-size: calc(10.5px * var(--plan-scale, 1));
   color: var(--plan-muted);
   letter-spacing: 0.04em;
   font-variant-numeric: tabular-nums;
@@ -1559,7 +1565,7 @@ button.weekBarBtn:hover .weekBarFill {
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  font-size: 9px;
+  font-size: calc(9px * var(--plan-scale, 1));
   letter-spacing: 0.07em;
   text-transform: uppercase;
   color: var(--plan-muted);
@@ -1569,7 +1575,7 @@ button.weekBarBtn:hover .weekBarFill {
   width: 52px;
 }
 .speedHint {
-  font-size: 10.5px;
+  font-size: calc(10.5px * var(--plan-scale, 1));
   color: var(--plan-muted);
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.03em;
@@ -1591,7 +1597,7 @@ button.weekBarBtn:hover .weekBarFill {
   justify-content: space-between;
   align-items: baseline;
   gap: 8px;
-  font-size: 11px;
+  font-size: calc(11px * var(--plan-scale, 1));
   color: var(--plan-muted);
 }
 .energyVal {
@@ -1600,11 +1606,11 @@ button.weekBarBtn:hover .weekBarFill {
   font-variant-numeric: tabular-nums;
 }
 .energyValStrong {
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--plan-scale, 1));
   font-weight: 700;
 }
 .energyHint {
-  font-size: 10.5px;
+  font-size: calc(10.5px * var(--plan-scale, 1));
   color: var(--plan-muted);
   font-style: italic;
 }
@@ -1618,7 +1624,7 @@ button.weekBarBtn:hover .weekBarFill {
   border-top: 1px solid var(--plan-rule);
   background: transparent;
   color: var(--plan-muted);
-  font-size: 11.5px;
+  font-size: calc(11.5px * var(--plan-scale, 1));
   letter-spacing: 0.03em;
   text-align: left;
   cursor: pointer;
@@ -1628,7 +1634,7 @@ button.weekBarBtn:hover .weekBarFill {
   color: var(--color-text);
 }
 .energySetupSub {
-  font-size: 9px;
+  font-size: calc(9px * var(--plan-scale, 1));
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
@@ -1641,7 +1647,7 @@ button.weekBarBtn:hover .weekBarFill {
   padding: 10px 12px;
   border: 1px solid var(--plan-card-border);
   border-radius: 8px;
-  font-size: 12px;
+  font-size: calc(12px * var(--plan-scale, 1));
   color: var(--color-text);
   font-variant-numeric: tabular-nums;
 }
@@ -1652,12 +1658,12 @@ button.weekBarBtn:hover .weekBarFill {
 }
 .energyReadoutLine span:first-child {
   color: var(--plan-muted);
-  font-size: 10.5px;
+  font-size: calc(10.5px * var(--plan-scale, 1));
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 .energyWarn {
-  font-size: 11px;
+  font-size: calc(11px * var(--plan-scale, 1));
   color: var(--plan-muted);
   font-style: italic;
 }
@@ -1670,7 +1676,7 @@ button.weekBarBtn:hover .weekBarFill {
   border-radius: 6px;
   background: transparent;
   color: var(--plan-muted);
-  font-size: 8.5px;
+  font-size: calc(8.5px * var(--plan-scale, 1));
   font-weight: 700;
   letter-spacing: 0.06em;
   cursor: pointer;
@@ -1686,7 +1692,7 @@ button.weekBarBtn:hover .weekBarFill {
   border: 1px dashed var(--plan-card-border);
   border-radius: 8px;
   color: var(--plan-muted);
-  font-size: 12px;
+  font-size: calc(12px * var(--plan-scale, 1));
   text-align: center;
 }
 
@@ -1700,7 +1706,7 @@ button.weekBarBtn:hover .weekBarFill {
 
 .exName {
   font-weight: 600;
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--plan-scale, 1));
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1719,7 +1725,7 @@ button.weekBarBtn:hover .weekBarFill {
   border: 1px solid var(--plan-card-border);
   border-radius: 6px;
   padding: 3px 6px;
-  font-size: 11px;
+  font-size: calc(11px * var(--plan-scale, 1));
   text-align: right;
   color: var(--color-text);
 }
@@ -1730,14 +1736,14 @@ button.weekBarBtn:hover .weekBarFill {
 }
 
 .setsLabel {
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   color: var(--plan-muted);
   font-weight: 600;
 }
 
 .overloadHint {
   margin-left: auto;
-  font-size: 9.5px;
+  font-size: calc(9.5px * var(--plan-scale, 1));
   color: var(--plan-muted);
   font-style: italic;
 }
@@ -1749,7 +1755,7 @@ button.weekBarBtn:hover .weekBarFill {
   padding: 9px 12px;
   border: 1.5px solid var(--plan-primary);
   border-radius: 8px;
-  font-size: 10.5px;
+  font-size: calc(10.5px * var(--plan-scale, 1));
   font-weight: 700;
   letter-spacing: 0.1em;
   color: var(--plan-primary);
@@ -1769,7 +1775,7 @@ button.weekBarBtn:hover .weekBarFill {
   background: transparent;
   border: none;
   padding: 4px 0;
-  font-size: 12px;
+  font-size: calc(12px * var(--plan-scale, 1));
   font-weight: 600;
   color: var(--color-text);
 }
@@ -1779,7 +1785,7 @@ button.weekBarBtn:hover .weekBarFill {
   background: transparent;
   border: none;
   padding: 4px 0;
-  font-size: 12px;
+  font-size: calc(12px * var(--plan-scale, 1));
   text-align: right;
   color: var(--plan-muted);
   font-variant-numeric: tabular-nums;
@@ -1797,7 +1803,7 @@ button.weekBarBtn:hover .weekBarFill {
 }
 
 .weekDay {
-  font-size: 9.5px;
+  font-size: calc(9.5px * var(--plan-scale, 1));
   letter-spacing: 0.1em;
   text-transform: uppercase;
   font-weight: 700;
@@ -1816,7 +1822,7 @@ button.weekBarBtn:hover .weekBarFill {
   border: 1px solid var(--plan-card-border);
   border-radius: 7px;
   padding: 5px 4px;
-  font-size: 11px;
+  font-size: calc(11px * var(--plan-scale, 1));
   color: var(--color-text);
 }
 
@@ -1828,7 +1834,7 @@ button.weekBarBtn:hover .weekBarFill {
 }
 
 .exEditHead {
-  font-size: 9px;
+  font-size: calc(9px * var(--plan-scale, 1));
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--plan-muted);
@@ -1874,7 +1880,7 @@ button.weekBarBtn:hover .weekBarFill {
   padding: 4px 11px;
   border: 1px solid var(--plan-card-border);
   border-radius: 999px;
-  font-size: 11px;
+  font-size: calc(11px * var(--plan-scale, 1));
   font-weight: 600;
   color: var(--color-text);
   background: transparent;
@@ -1890,12 +1896,12 @@ button.weekBarBtn:hover .weekBarFill {
   composes: presetChip;
   border-style: dashed;
   color: var(--plan-muted);
-  font-size: 10.5px;
+  font-size: calc(10.5px * var(--plan-scale, 1));
 }
 
 .presetCal {
   color: var(--plan-muted);
-  font-size: 9.5px;
+  font-size: calc(9.5px * var(--plan-scale, 1));
   font-variant-numeric: tabular-nums;
 }
 
@@ -1917,14 +1923,14 @@ button.weekBarBtn:hover .weekBarFill {
   border: 1px solid var(--plan-rule);
   border-radius: 9px;
   color: var(--plan-muted);
-  font-size: 12px;
+  font-size: calc(12px * var(--plan-scale, 1));
   font-style: italic;
 }
 
 .aiText {
   flex: 1 1 200px;
   min-width: 0;
-  font-size: 12px;
+  font-size: calc(12px * var(--plan-scale, 1));
   white-space: pre-line;
 }
 
@@ -1935,7 +1941,7 @@ button.weekBarBtn:hover .weekBarFill {
   padding: 4px 11px;
   border: 1px solid var(--plan-primary);
   border-radius: 999px;
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   font-weight: 700;
   letter-spacing: 0.08em;
   color: var(--plan-primary);
@@ -1964,7 +1970,7 @@ button.weekBarBtn:hover .weekBarFill {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   font-weight: 700;
   letter-spacing: 0.08em;
   color: var(--plan-primary);
@@ -2010,7 +2016,7 @@ button.weekBarBtn:hover .weekBarFill {
 }
 
 .slotSubtotal {
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   color: var(--plan-muted);
   font-variant-numeric: tabular-nums;
 }
@@ -2023,7 +2029,7 @@ button.weekBarBtn:hover .weekBarFill {
   padding: 3px 9px;
   border: 1px solid var(--plan-card-border);
   border-radius: 999px;
-  font-size: 9.5px;
+  font-size: calc(9.5px * var(--plan-scale, 1));
   font-weight: 700;
   letter-spacing: 0.08em;
   color: var(--plan-muted);
@@ -2039,7 +2045,7 @@ button.weekBarBtn:hover .weekBarFill {
 .slotEmpty {
   padding: 8px 0 4px;
   color: var(--plan-muted);
-  font-size: 11px;
+  font-size: calc(11px * var(--plan-scale, 1));
   font-style: italic;
 }
 
@@ -2056,7 +2062,7 @@ button.weekBarBtn:hover .weekBarFill {
   background: transparent;
   border: none;
   padding: 0;
-  font-size: 12px;
+  font-size: calc(12px * var(--plan-scale, 1));
   font-weight: 600;
   color: var(--color-text);
   width: 100%;
@@ -2067,7 +2073,7 @@ button.weekBarBtn:hover .weekBarFill {
 }
 
 .mealMacro {
-  font-size: 9px;
+  font-size: calc(9px * var(--plan-scale, 1));
   color: var(--plan-muted);
   font-variant-numeric: tabular-nums;
 }
@@ -2077,7 +2083,7 @@ button.weekBarBtn:hover .weekBarFill {
   flex: 0 0 auto;
   background: transparent;
   border: none;
-  font-size: 12px;
+  font-size: calc(12px * var(--plan-scale, 1));
   text-align: right;
   color: var(--color-text);
   font-variant-numeric: tabular-nums;
@@ -2088,7 +2094,7 @@ button.weekBarBtn:hover .weekBarFill {
 }
 
 .kcalUnit {
-  font-size: 9px;
+  font-size: calc(9px * var(--plan-scale, 1));
   color: var(--plan-muted);
   flex: 0 0 auto;
 }
@@ -2118,19 +2124,19 @@ button.weekBarBtn:hover .weekBarFill {
 .kcalLeftBig {
   font-family: var(--plan-display-font);
   font-weight: 700;
-  font-size: 19px;
+  font-size: calc(19px * var(--plan-scale, 1));
   line-height: 1;
   font-variant-numeric: tabular-nums;
 }
 
 .kcalLeftSub {
-  font-size: 10.5px;
+  font-size: calc(10.5px * var(--plan-scale, 1));
   color: var(--plan-muted);
 }
 
 /* Cardio burned — informational only, deliberately NOT netted into kcal-left. */
 .burnedLine {
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   color: var(--plan-muted);
   font-variant-numeric: tabular-nums;
   margin-top: 1px;
@@ -2146,7 +2152,7 @@ button.weekBarBtn:hover .weekBarFill {
   display: flex;
   justify-content: space-between;
   gap: 8px;
-  font-size: 11px;
+  font-size: calc(11px * var(--plan-scale, 1));
   color: var(--plan-muted);
 }
 
@@ -2170,7 +2176,7 @@ button.weekBarBtn:hover .weekBarFill {
   display: flex;
   justify-content: space-between;
   gap: 8px;
-  font-size: 11px;
+  font-size: calc(11px * var(--plan-scale, 1));
   border-top: 1px solid var(--plan-rule);
   padding-top: 8px;
   color: var(--plan-muted);
@@ -2197,7 +2203,7 @@ button.weekBarBtn:hover .weekBarFill {
   border: 1px solid var(--plan-card-border);
   color: var(--color-text);
   font-weight: 600;
-  font-size: 11px;
+  font-size: calc(11px * var(--plan-scale, 1));
   background: transparent;
   cursor: pointer;
 }
@@ -2211,7 +2217,7 @@ button.weekBarBtn:hover .weekBarFill {
 }
 
 .slotHint {
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   color: var(--plan-muted);
   font-style: italic;
 }
@@ -2255,12 +2261,12 @@ button.weekBarBtn:hover .weekBarFill {
 
 .presetName {
   font-weight: 700;
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--plan-scale, 1));
   line-height: 1.25;
 }
 
 .presetMacroLine {
-  font-size: 10.5px;
+  font-size: calc(10.5px * var(--plan-scale, 1));
   color: var(--plan-muted);
   font-variant-numeric: tabular-nums;
 }
@@ -2300,7 +2306,7 @@ button.weekBarBtn:hover .weekBarFill {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  font-size: 8.5px;
+  font-size: calc(8.5px * var(--plan-scale, 1));
   letter-spacing: 0.1em;
   color: var(--plan-muted);
   font-weight: 700;
@@ -2311,7 +2317,7 @@ button.weekBarBtn:hover .weekBarFill {
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   font-weight: 700;
   letter-spacing: 0.08em;
   color: var(--plan-danger);
@@ -2328,7 +2334,7 @@ button.weekBarBtn:hover .weekBarFill {
   align-items: center;
   justify-content: center;
   gap: 6px;
-  font-size: 11.5px;
+  font-size: calc(11.5px * var(--plan-scale, 1));
   font-weight: 600;
   color: var(--plan-muted);
   background: transparent;
@@ -2373,11 +2379,11 @@ button.weekBarBtn:hover .weekBarFill {
   composes: square;
   width: 22px;
   height: 22px;
-  font-size: 13px;
+  font-size: calc(13px * var(--plan-scale, 1));
 }
 
 .nonnegLabel {
-  font-size: 10.5px;
+  font-size: calc(10.5px * var(--plan-scale, 1));
   letter-spacing: 0.14em;
   font-weight: 700;
   text-transform: uppercase;
@@ -2389,7 +2395,7 @@ button.weekBarBtn:hover .weekBarFill {
   font-family: var(--plan-display-font);
   font-weight: 700;
   letter-spacing: 0.34em;
-  font-size: 12px;
+  font-size: calc(12px * var(--plan-scale, 1));
   color: var(--plan-muted);
   text-transform: uppercase;
 }

--- a/apps/web/src/features/daily-plan/DailyPlanView.tsx
+++ b/apps/web/src/features/daily-plan/DailyPlanView.tsx
@@ -326,6 +326,18 @@ export function DailyPlanView({
   const colw = 340;
   const gap = 14;
 
+  // Content text scale (SIZE control): drives --plan-scale, which every plan
+  // font-size and checkbox control multiplies against. Set on :root, not
+  // .planRoot — the pill, jump sheet, and modals portal to <body>.
+  const textScale = settings.textScale;
+  useEffect(() => {
+    const scale = textScale === 's' ? '1' : textScale === 'l' ? '1.25' : '1.12';
+    document.documentElement.style.setProperty('--plan-scale', scale);
+    return () => {
+      document.documentElement.style.removeProperty('--plan-scale');
+    };
+  }, [textScale]);
+
   // span-2 is only legal when the grid actually fits two columns.
   const gridRef = useRef<HTMLDivElement | null>(null);
   const [canWide, setCanWide] = useState(true);
@@ -844,6 +856,16 @@ export function DailyPlanView({
       >
         <SaveIndicator status={saveStatus} />
         <Segmented
+          label="Size"
+          options={[
+            ['s', 'A−'],
+            ['m', 'A'],
+            ['l', 'A+'],
+          ]}
+          value={settings.textScale}
+          onChange={(value) => patchSettings({ textScale: value as 's' | 'm' | 'l' })}
+        />
+        <Segmented
           label="Theme"
           options={[
             ['dark', 'DARK'],
@@ -857,7 +879,7 @@ export function DailyPlanView({
         <button
           type="button"
           className={styles.pillBtn}
-          style={{ fontSize: 11, letterSpacing: '.08em' }}
+          style={{ fontSize: 'calc(11px * var(--plan-scale, 1))', letterSpacing: '.08em' }}
           onClick={() => setCustomizeOpen(true)}
         >
           <svg
@@ -895,7 +917,7 @@ export function DailyPlanView({
       {weekError && !weekReady && (
         <div className={styles.hiddenBar} role="alert">
           <span className={styles.hiddenBarLabel}>Offline?</span>
-          <span style={{ fontSize: 12 }}>
+          <span style={{ fontSize: 'calc(12px * var(--plan-scale, 1))' }}>
             Couldn&apos;t load this day&apos;s plan — editing is paused so nothing gets overwritten.
           </span>
           <button type="button" className={styles.hiddenChip} onClick={() => void refetchWeek()}>
@@ -907,7 +929,7 @@ export function DailyPlanView({
       {isToday && carry.count > 0 && !day.carryHandled && (
         <div className={styles.hiddenBar} role="status">
           <span className={styles.hiddenBarLabel}>Yesterday</span>
-          <span style={{ fontSize: 12 }}>
+          <span style={{ fontSize: 'calc(12px * var(--plan-scale, 1))' }}>
             {carryError
               ? "Couldn't add the tasks — check your connection and try again."
               : `${carry.count} unfinished item${carry.count > 1 ? 's' : ''} from yesterday`}
@@ -1151,7 +1173,7 @@ function Segmented(props: {
         border: '1px solid var(--plan-card-border)',
         borderRadius: 999,
         overflow: 'hidden',
-        fontSize: 11,
+        fontSize: 'calc(11px * var(--plan-scale, 1))',
         letterSpacing: '.08em',
       }}
     >

--- a/apps/web/src/features/daily-plan/JumpSheet.module.css
+++ b/apps/web/src/features/daily-plan/JumpSheet.module.css
@@ -22,7 +22,7 @@
   background: var(--plan-secbar);
   color: var(--plan-secbar-text);
   font-family: var(--plan-label-font);
-  font-size: 10.5px;
+  font-size: calc(10.5px * var(--plan-scale, 1));
   font-weight: 700;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -194,7 +194,7 @@
 
 .title {
   font-family: var(--plan-label-font);
-  font-size: 11px;
+  font-size: calc(11px * var(--plan-scale, 1));
   font-weight: 700;
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -202,7 +202,7 @@
 }
 
 .hint {
-  font-size: 10.5px;
+  font-size: calc(10.5px * var(--plan-scale, 1));
   color: var(--plan-muted);
   opacity: 0.8;
 }
@@ -307,7 +307,7 @@
 
 .tileLabel {
   font-family: var(--plan-label-font);
-  font-size: 10.5px;
+  font-size: calc(10.5px * var(--plan-scale, 1));
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -319,7 +319,7 @@
 }
 
 .tileStatus {
-  font-size: 10.5px;
+  font-size: calc(10.5px * var(--plan-scale, 1));
   color: var(--plan-muted);
   font-variant-numeric: tabular-nums;
   overflow: hidden;
@@ -345,7 +345,7 @@
   background: transparent;
   color: var(--plan-muted);
   font-family: var(--plan-label-font);
-  font-size: 10px;
+  font-size: calc(10px * var(--plan-scale, 1));
   font-weight: 700;
   letter-spacing: 0.12em;
   text-transform: uppercase;

--- a/apps/web/src/features/daily-plan/MealsSection.tsx
+++ b/apps/web/src/features/daily-plan/MealsSection.tsx
@@ -326,7 +326,7 @@ export function MealsSection(props: MealsSectionProps) {
         <input
           dir="auto"
           className={styles.smallInput}
-          style={{ flex: 1, padding: '9px 12px', fontSize: 12.5 }}
+          style={{ flex: 1, padding: '9px 12px', fontSize: 'calc(12.5px * var(--plan-scale, 1))' }}
           placeholder="Log food: “2 eggs and toast for breakfast”…"
           aria-label="Log food"
           value={draft}
@@ -336,7 +336,11 @@ export function MealsSection(props: MealsSectionProps) {
         <button
           type="button"
           className={styles.primaryBtn}
-          style={{ padding: '9px 16px', letterSpacing: '.08em', fontSize: 11 }}
+          style={{
+            padding: '9px 16px',
+            letterSpacing: '.08em',
+            fontSize: 'calc(11px * var(--plan-scale, 1))',
+          }}
           onClick={() => send(draft, false)}
         >
           LOG
@@ -344,7 +348,10 @@ export function MealsSection(props: MealsSectionProps) {
       </div>
 
       <div className={styles.pinnedRow}>
-        <span className={styles.sectionMiniMuted} style={{ fontSize: 9 }}>
+        <span
+          className={styles.sectionMiniMuted}
+          style={{ fontSize: 'calc(9px * var(--plan-scale, 1))' }}
+        >
           Pinned
         </span>
         {pinned.map((preset, i) => (
@@ -387,7 +394,10 @@ export function MealsSection(props: MealsSectionProps) {
 
       {props.recentItems.length > 0 && (
         <div className={styles.pinnedRow}>
-          <span className={styles.sectionMiniMuted} style={{ fontSize: 9 }}>
+          <span
+            className={styles.sectionMiniMuted}
+            style={{ fontSize: 'calc(9px * var(--plan-scale, 1))' }}
+          >
             Recent
           </span>
           {props.recentItems.map((item, i) => (
@@ -924,7 +934,7 @@ export function SavedMealsModal(props: SavedMealsProps) {
               alignSelf: 'flex-start',
               borderRadius: 999,
               letterSpacing: '.08em',
-              fontSize: 10.5,
+              fontSize: 'calc(10.5px * var(--plan-scale, 1))',
             }}
             onClick={() => {
               const name = manual.n.trim();

--- a/apps/web/src/features/daily-plan/PlanSettingsModal.tsx
+++ b/apps/web/src/features/daily-plan/PlanSettingsModal.tsx
@@ -325,7 +325,11 @@ export function PlanSettingsModal(props: PlanSettingsModalProps) {
               </button>
             ))}
           </div>
-          <div style={{ fontSize: 12, color: 'var(--plan-muted)' }}>{templateSummary}</div>
+          <div
+            style={{ fontSize: 'calc(12px * var(--plan-scale, 1))', color: 'var(--plan-muted)' }}
+          >
+            {templateSummary}
+          </div>
           <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
             <button
               type="button"
@@ -354,7 +358,13 @@ export function PlanSettingsModal(props: PlanSettingsModalProps) {
               </button>
             )}
           </div>
-          <div style={{ fontSize: 11, color: 'var(--plan-muted)', fontStyle: 'italic' }}>
+          <div
+            style={{
+              fontSize: 'calc(11px * var(--plan-scale, 1))',
+              color: 'var(--plan-muted)',
+              fontStyle: 'italic',
+            }}
+          >
             Build the day you want once (schedule, priorities), then save it here. Yesterday&apos;s
             unfinished items are offered as real tasks by the carry-over bar.
           </div>
@@ -630,7 +640,10 @@ export function PlanSettingsModal(props: PlanSettingsModalProps) {
         </Section>
 
         <Section title="Your words">
-          <label className={styles.macroLabel} style={{ fontSize: 9 }}>
+          <label
+            className={styles.macroLabel}
+            style={{ fontSize: 'calc(9px * var(--plan-scale, 1))' }}
+          >
             MASTHEAD SUBTITLE
             <input
               dir="auto"
@@ -642,7 +655,10 @@ export function PlanSettingsModal(props: PlanSettingsModalProps) {
               onChange={(e) => props.patchSettings({ subtitle: e.target.value })}
             />
           </label>
-          <label className={styles.macroLabel} style={{ fontSize: 9 }}>
+          <label
+            className={styles.macroLabel}
+            style={{ fontSize: 'calc(9px * var(--plan-scale, 1))' }}
+          >
             MOTTO (BOTTOM LINE)
             <input
               dir="auto"

--- a/apps/web/src/features/daily-plan/WorkoutCard.tsx
+++ b/apps/web/src/features/daily-plan/WorkoutCard.tsx
@@ -332,7 +332,12 @@ export function WorkoutBody(props: WorkoutBodyProps) {
                     }
                     onCommit={(v) => (timed ? setMin(i, v) : setKg(i, v))}
                   />
-                  <span style={{ fontSize: 10, color: 'var(--plan-muted)' }}>
+                  <span
+                    style={{
+                      fontSize: 'calc(10px * var(--plan-scale, 1))',
+                      color: 'var(--plan-muted)',
+                    }}
+                  >
                     {timed ? 'min' : 'kg'}
                   </span>
                 </span>

--- a/apps/web/src/features/daily-plan/cards.tsx
+++ b/apps/web/src/features/daily-plan/cards.tsx
@@ -38,7 +38,11 @@ export function CircleCheck(props: {
   onToggle: () => void;
   className?: string | undefined;
 }) {
-  const style: CSSProperties = { width: props.size, height: props.size };
+  // Scales with the plan's SIZE setting — bigger text deserves bigger targets.
+  const style: CSSProperties = {
+    width: `calc(${props.size}px * var(--plan-scale, 1))`,
+    height: `calc(${props.size}px * var(--plan-scale, 1))`,
+  };
   return (
     <button
       type="button"

--- a/packages/shared/src/daily-plan.ts
+++ b/packages/shared/src/daily-plan.ts
@@ -357,6 +357,9 @@ export const DEFAULT_SUBTITLE = 'discipline · focus · execution';
 
 export const dailyPlanSettingsSchema = z.object({
   density: z.enum(['compact', 'roomy']).default('compact'),
+  /** Content text scale inside the plan cards — 's' is the original desktop
+      density; 'm' (default) and 'l' step fonts/controls up for phones. */
+  textScale: z.enum(['s', 'm', 'l']).default('m'),
   secOrder: z.array(planKey).max(32).default([]),
   secWide: boundedRecord(z.boolean(), 32).default({}),
   hidden: boundedRecord(z.boolean(), 32).default({}),


### PR DESCRIPTION
## Summary

Phone readability round, from on-device feedback (screenshots circled the section bars):

- **Section bars switch from the display serif to the label sans.** In paper theme the bars were Playfair Display at 11px, reversed white-on-ink with wide letter-spacing — hairline serif strokes are unreadable at that size. They now use the quiet label sans (DM Sans in paper); dark theme is visually unchanged since its display and label faces are the same sans. The serif stays where it belongs: the DAILY PLAN masthead, routine titles, and other large display text.
- **Paper's muted ink darkens** (`#5c5c56` → `#4e4e47`) — small muted text (macros, hints, statuses) needed more contrast on the warm paper ground.
- **New SIZE control (A− / A / A+)** next to DARK/PAPER, persisted as `textScale: 's'|'m'|'l'` in plan settings (shared schema, default-safe for old blobs). It sets a root-level `--plan-scale` (1 / 1.12 / 1.25) that every plan `font-size` — 100+ declarations swept into `calc(... * var(--plan-scale))`, plus inline styles and the checkbox/circle tap targets — multiplies against. Content, buttons, and inputs grow; the card grid and panel layout stay put. **The default (`m`) is one step bigger than the previous fixed sizing**, tuned for phones; `A−` reproduces the old sizing exactly.

**Verified in-browser** (390×844, paper, fresh visitor): default boots at scale 1.12 with sans section bars; A+ → 1.25 and persists `textScale: 'l'` through the debounced save; A− → exactly the old 11px metrics; choice survives reload. Full workspace suite green (shared + server + 240 web tests).

## Change Type
- [x] Product behavior
- [ ] Feature scope
- [x] Frontend behavior
- [ ] Backend behavior
- [ ] API contract
- [x] Data model
- [ ] Architecture
- [ ] Operations / deployment

## Documentation Impact
- [x] I evaluated documentation impact.
- [ ] I updated the relevant docs.
- [x] No docs update was needed, and I explained why below.

## Docs Updated

None.

## If no docs were updated, explain why

The only contract change is an additive settings field (`textScale`) with a schema default — old blobs parse unchanged, and no docs describe the plan settings shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV)_