### PR TITLE
fix(web): stale-shell hardening — cache headers, sw v2, updateViaCache

### DIFF
--- a/apps/server/src/http/app.test.ts
+++ b/apps/server/src/http/app.test.ts
@@ -127,6 +127,7 @@ describe('createApp public surface', () => {
 describe('createApp production SPA serving (WEB_DIST_DIR)', () => {
   const distDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lifeline-web-'));
   fs.writeFileSync(path.join(distDir, 'index.html'), '<!doctype html><title>Lifeline SPA</title>');
+  fs.writeFileSync(path.join(distDir, 'sw.js'), '// worker');
   fs.mkdirSync(path.join(distDir, 'assets'), { recursive: true });
   fs.writeFileSync(path.join(distDir, 'assets', 'app.js'), 'console.log("bundle");');
 
@@ -135,17 +136,25 @@ describe('createApp production SPA serving (WEB_DIST_DIR)', () => {
 
   afterAll(() => fs.rmSync(distDir, { recursive: true, force: true }));
 
-  it('serves index.html at the root', async () => {
+  it('serves index.html at the root, uncached', async () => {
     const response = await request(spaApp).get('/');
     expect(response.status).toBe(200);
     expect(response.headers['content-type']).toContain('text/html');
     expect(response.text).toContain('Lifeline SPA');
+    expect(response.headers['cache-control']).toBe('no-cache');
   });
 
-  it('serves fingerprinted static assets', async () => {
+  it('serves fingerprinted static assets as immutable', async () => {
     const response = await request(spaApp).get('/assets/app.js');
     expect(response.status).toBe(200);
     expect(response.text).toContain('bundle');
+    expect(response.headers['cache-control']).toBe('public, max-age=31536000, immutable');
+  });
+
+  it('never long-caches non-fingerprinted root files (sw.js pins old shells)', async () => {
+    const response = await request(spaApp).get('/sw.js');
+    expect(response.status).toBe(200);
+    expect(response.headers['cache-control']).toBe('no-cache');
   });
 
   it('falls back to index.html for client-side routes', async () => {

--- a/apps/server/src/http/spa.ts
+++ b/apps/server/src/http/spa.ts
@@ -12,13 +12,21 @@ import express, { type RequestHandler } from 'express';
 export function createSpaHandler(webDistDir: string): RequestHandler {
   const resolvedDir = path.resolve(webDistDir);
   const indexHtml = path.join(resolvedDir, 'index.html');
+  const assetsDir = path.join(resolvedDir, 'assets') + path.sep;
   const staticMiddleware = express.static(resolvedDir, {
     index: false,
-    // Vite fingerprints asset filenames, so they can be cached hard; index.html
-    // (served by the fallback below) is not cached so deploys take effect.
-    maxAge: '1y',
+    // ONLY Vite's fingerprinted /assets/* files are immutable. Everything
+    // else in the dist root (index.html, sw.js, manifest, icons) must
+    // revalidate on every load — a year-cached sw.js or shell is exactly how
+    // a phone keeps booting a previous release's asset URLs after a deploy
+    // (blank page: the old hashed files no longer exist).
+    maxAge: 0,
     setHeaders: (res, filePath) => {
-      if (filePath.endsWith('index.html')) res.setHeader('Cache-Control', 'no-cache');
+      if (filePath.startsWith(assetsDir)) {
+        res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+      } else {
+        res.setHeader('Cache-Control', 'no-cache');
+      }
     },
   });
 

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -5,7 +5,8 @@
  * - hashed /assets/*: cache-first (content-hashed, immutable);
  * - everything else (API calls included) goes straight to the network.
  */
-const CACHE = 'lifeline-shell-v1';
+// v2: purge shells cached by the v1 worker (it could cache a non-ok response).
+const CACHE = 'lifeline-shell-v2';
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -37,8 +38,12 @@ self.addEventListener('fetch', (event) => {
     event.respondWith(
       fetch(request)
         .then((response) => {
-          const copy = response.clone();
-          void caches.open(CACHE).then((cache) => cache.put('/', copy));
+          // Only a healthy shell may become the offline fallback — caching a
+          // mid-deploy 502 here would serve an error page while offline.
+          if (response.ok) {
+            const copy = response.clone();
+            void caches.open(CACHE).then((cache) => cache.put('/', copy));
+          }
           return response;
         })
         .catch(() => caches.match('/').then((hit) => hit ?? Response.error())),

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -16,7 +16,9 @@ createRoot(container).render(
 // Installable PWA shell (prod only — the dev server must never be cached).
 if (import.meta.env.PROD && 'serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch(() => {
+    // updateViaCache 'none': the worker script itself must always be fetched
+    // from the network — an HTTP-cached sw.js pins clients to an old shell.
+    navigator.serviceWorker.register('/sw.js', { updateViaCache: 'none' }).catch(() => {
       // Offline shell is progressive enhancement — never block the app on it.
     });
   });


### PR DESCRIPTION
## Summary

Field report: after the last deploy, Safari on iPhone showed a blank white page while other browsers loaded fine — the classic stale-shell failure (a cached shell/worker booting the previous release's hashed asset URLs, which the new release deleted). Auditing the serving path found three real holes; all closed:

- **`express.static` long-cached everything.** `maxAge: '1y'` applied to the whole dist with only `index.html` overridden — so `sw.js`, `manifest.webmanifest`, and icons carried a year of HTTP cache. Now only fingerprinted `/assets/*` get `public, max-age=31536000, immutable`; every non-hashed file (including the worker script) is `no-cache`.
- **The service worker's navigation handler cached responses without an `ok` guard** — a mid-deploy 502 could be stored as the offline shell. Guarded now, and the cache name is bumped to `lifeline-shell-v2` so shells cached by the v1 worker are purged on activate.
- **Worker registration now passes `updateViaCache: 'none'`** so the browser always fetches `sw.js` from the network when checking for updates.

Server tests now pin the per-file-class cache policy (root → no-cache, `/assets/*` → immutable, `sw.js` → no-cache) so this can't regress silently.

## Change Type
- [ ] Product behavior
- [ ] Feature scope
- [x] Frontend behavior
- [x] Backend behavior
- [ ] API contract
- [ ] Data model
- [ ] Architecture
- [x] Operations / deployment

## Documentation Impact
- [x] I evaluated documentation impact.
- [ ] I updated the relevant docs.
- [x] No docs update was needed, and I explained why below.

## Docs Updated

None.

## If no docs were updated, explain why

Serving/caching internals; no interface or operational procedure changes (deploys work exactly as before — they just propagate reliably now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV)_