### PR TITLE
feat(plan): rework Add Food — manual-first, fuzzy filter, scrollable saved meals

### DIFF
--- a/apps/web/src/features/daily-plan/DailyPlan.module.css
+++ b/apps/web/src/features/daily-plan/DailyPlan.module.css
@@ -2228,6 +2228,18 @@ button.weekBarBtn:hover .weekBarFill {
   gap: 8px;
 }
 
+/* The saved-meal list scrolls inside its own region so the manual-entry row
+   and Add button above it stay put no matter how many meals are saved. */
+.presetScroll {
+  max-height: min(46vh, 420px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+  scrollbar-color: var(--plan-card-border) transparent;
+  padding: 2px;
+  margin: -2px;
+}
+
 .presetCard {
   border: 1px solid var(--plan-card-border);
   border-radius: 10px;

--- a/apps/web/src/features/daily-plan/MealsSection.tsx
+++ b/apps/web/src/features/daily-plan/MealsSection.tsx
@@ -10,6 +10,7 @@ import type {
 import { MEAL_SLOTS, bmr, dayBalance, maintenanceBase } from '@lifeline/shared';
 import { Modal } from '../../shared/ui/Modal';
 import { detectMeal, guessSlot, logSummary, parseFood, photoFoods } from './lib/food-parser';
+import { filterMeals } from './lib/meal-filter';
 import styles from './DailyPlan.module.css';
 
 /**
@@ -748,156 +749,31 @@ export function SavedMealsModal(props: SavedMealsProps) {
     });
   };
 
+  // The food-name field does double duty: it's the manual-entry name AND the
+  // saved-meal filter. Typing narrows the list fuzzily (see meal-filter).
+  const query = manual.n;
+  const matches = filterMeals(settings.presets, query);
+  const filtering = query.trim().length > 0;
+
+  const addManual = () => {
+    const name = manual.n.trim();
+    if (!name) return;
+    props.onManualAdd(activeSlot, {
+      n: name,
+      cal: num(manual.cal),
+      p: num(manual.p),
+      c: num(manual.c),
+      f: num(manual.f),
+    });
+    setManual({ n: '', cal: '', p: '', c: '', f: '' });
+  };
+
   return (
     <Modal open={props.open} onClose={props.onClose} title="Add Food">
       <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-        <div className={styles.slotChipRow}>
-          <span className={styles.sectionMiniMuted}>Log to</span>
-          {MEAL_SLOTS.map((slot) => (
-            <button
-              key={slot}
-              type="button"
-              className={activeSlot === slot ? styles.slotChipActive : styles.slotChip}
-              onClick={() => props.setSlot(slot)}
-            >
-              {SLOT_LABELS[slot]}
-            </button>
-          ))}
-          {props.slot === null && <span className={styles.slotHint}>auto: {autoSlot}</span>}
-        </div>
-
+        {/* ── Manual entry FIRST — the fast path, and the saved-meal filter. ── */}
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-          <div className={styles.sectionMiniMuted}>Saved meals — tap to log</div>
-          <div className={styles.presetGrid}>
-            {settings.presets.map((preset, i) => (
-              <div key={i} className={styles.presetCard}>
-                <div className={styles.presetCardTop}>
-                  <button
-                    type="button"
-                    className={styles.presetLog}
-                    onClick={() => props.onLog(preset, activeSlot)}
-                  >
-                    <span dir="auto" className={styles.presetName}>
-                      {preset.name}
-                    </span>
-                    <span className={styles.presetMacroLine}>
-                      {preset.cal} kcal · P {preset.p} · C {preset.c} · F {preset.f}
-                    </span>
-                  </button>
-                  <button
-                    type="button"
-                    className={preset.pinned ? styles.presetIconBtnActive : styles.presetIconBtn}
-                    title="Pin to Daily Plan"
-                    aria-label={`Pin ${preset.name}`}
-                    aria-pressed={preset.pinned}
-                    onClick={() => updatePreset(i, { pinned: !preset.pinned })}
-                  >
-                    <svg
-                      width="12"
-                      height="12"
-                      viewBox="0 0 24 24"
-                      fill={preset.pinned ? 'currentColor' : 'none'}
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      aria-hidden="true"
-                    >
-                      <path d="M12 17v5" />
-                      <path d="M9 3h6l1 7 2.5 2.5H5.5L8 10z" />
-                    </svg>
-                  </button>
-                  <button
-                    type="button"
-                    className={
-                      props.editIndex === i ? styles.presetIconBtnActive : styles.presetIconBtn
-                    }
-                    style={{ marginRight: 6 }}
-                    title="Edit"
-                    aria-label={`Edit ${preset.name}`}
-                    onClick={() => props.setEditIndex(props.editIndex === i ? null : i)}
-                  >
-                    <svg
-                      width="12"
-                      height="12"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      aria-hidden="true"
-                    >
-                      <path d="M17 3a2.8 2.8 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5z" />
-                    </svg>
-                  </button>
-                </div>
-                {props.editIndex === i && (
-                  <div className={styles.presetEditor}>
-                    <input
-                      dir="auto"
-                      className={styles.smallInput}
-                      style={{ width: '100%', boxSizing: 'border-box', fontWeight: 600 }}
-                      value={preset.name}
-                      aria-label="Meal name"
-                      onChange={(e) => updatePreset(i, { name: e.target.value })}
-                    />
-                    <div className={styles.macroGrid}>
-                      {(
-                        [
-                          ['KCAL', 'cal'],
-                          ['P', 'p'],
-                          ['C', 'c'],
-                          ['F', 'f'],
-                        ] as const
-                      ).map(([label, field]) => (
-                        <label key={field} className={styles.macroLabel}>
-                          {label}
-                          <input
-                            type="number"
-                            className={styles.smallInput}
-                            style={{ width: '100%', boxSizing: 'border-box', padding: '5px 6px' }}
-                            value={preset[field]}
-                            onChange={(e) => updatePreset(i, { [field]: num(e.target.value) })}
-                          />
-                        </label>
-                      ))}
-                    </div>
-                    <button
-                      type="button"
-                      className={styles.dangerLink}
-                      onClick={() => {
-                        props.setEditIndex(null);
-                        props.patchSettings({
-                          presets: settings.presets.filter((_, j) => j !== i),
-                        });
-                      }}
-                    >
-                      DELETE MEAL
-                    </button>
-                  </div>
-                )}
-              </div>
-            ))}
-            <button
-              type="button"
-              className={styles.newPresetCard}
-              onClick={() => {
-                const presets = [
-                  ...settings.presets,
-                  { name: 'New meal', cal: 400, p: 25, c: 40, f: 12, pinned: false },
-                ];
-                props.patchSettings({ presets });
-                props.setEditIndex(presets.length - 1);
-              }}
-            >
-              + New saved meal
-            </button>
-          </div>
-        </div>
-
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-          <div className={styles.sectionMiniMuted}>Or enter manually</div>
+          <div className={styles.sectionMiniMuted}>Add food — type to filter saved meals</div>
           <div className={styles.manualGrid}>
             <input
               dir="auto"
@@ -906,6 +782,9 @@ export function SavedMealsModal(props: SavedMealsProps) {
               aria-label="Manual food name"
               value={manual.n}
               onChange={(e) => setManual({ ...manual, n: e.target.value })}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') addManual();
+              }}
             />
             {(
               [
@@ -927,30 +806,190 @@ export function SavedMealsModal(props: SavedMealsProps) {
               />
             ))}
           </div>
-          <button
-            type="button"
-            className={styles.primaryBtn}
+          {/* Slot picker sits right beside the ADD action so the target meal
+              is chosen at the moment of adding (and governs saved-meal taps). */}
+          <div
             style={{
-              alignSelf: 'flex-start',
-              borderRadius: 999,
-              letterSpacing: '.08em',
-              fontSize: 'calc(10.5px * var(--plan-scale, 1))',
-            }}
-            onClick={() => {
-              const name = manual.n.trim();
-              if (!name) return;
-              props.onManualAdd(activeSlot, {
-                n: name,
-                cal: num(manual.cal),
-                p: num(manual.p),
-                c: num(manual.c),
-                f: num(manual.f),
-              });
-              setManual({ n: '', cal: '', p: '', c: '', f: '' });
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 10,
+              flexWrap: 'wrap',
             }}
           >
-            ADD TO {SLOT_LABELS[activeSlot].toUpperCase()}
-          </button>
+            <div className={styles.slotChipRow}>
+              <span className={styles.sectionMiniMuted}>Log to</span>
+              {MEAL_SLOTS.map((slot) => (
+                <button
+                  key={slot}
+                  type="button"
+                  className={activeSlot === slot ? styles.slotChipActive : styles.slotChip}
+                  onClick={() => props.setSlot(slot)}
+                >
+                  {SLOT_LABELS[slot]}
+                </button>
+              ))}
+              {props.slot === null && <span className={styles.slotHint}>auto: {autoSlot}</span>}
+            </div>
+            <button
+              type="button"
+              className={styles.primaryBtn}
+              style={{
+                borderRadius: 999,
+                letterSpacing: '.08em',
+                fontSize: 'calc(10.5px * var(--plan-scale, 1))',
+              }}
+              onClick={addManual}
+            >
+              ADD TO {SLOT_LABELS[activeSlot].toUpperCase()}
+            </button>
+          </div>
+        </div>
+
+        {/* ── Saved meals BELOW — New-on-top, scrollable, filtered by name. ── */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <div className={styles.sectionMiniMuted}>
+            {filtering
+              ? `Saved meals — ${matches.length} match${matches.length === 1 ? '' : 'es'}`
+              : 'Saved meals — tap to log'}
+          </div>
+          <div className={styles.presetScroll}>
+            <div className={styles.presetGrid}>
+              <button
+                type="button"
+                className={styles.newPresetCard}
+                onClick={() => {
+                  // Prefill from whatever's in the name field so a search that
+                  // finds nothing turns into the meal you were about to type.
+                  const name = manual.n.trim() || 'New meal';
+                  const presets = [
+                    ...settings.presets,
+                    { name, cal: 400, p: 25, c: 40, f: 12, pinned: false },
+                  ];
+                  props.patchSettings({ presets });
+                  props.setEditIndex(presets.length - 1);
+                }}
+              >
+                + New saved meal
+              </button>
+              {matches.map(({ item: preset, index: i }) => (
+                <div key={i} className={styles.presetCard}>
+                  <div className={styles.presetCardTop}>
+                    <button
+                      type="button"
+                      className={styles.presetLog}
+                      onClick={() => props.onLog(preset, activeSlot)}
+                    >
+                      <span dir="auto" className={styles.presetName}>
+                        {preset.name}
+                      </span>
+                      <span className={styles.presetMacroLine}>
+                        {preset.cal} kcal · P {preset.p} · C {preset.c} · F {preset.f}
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      className={preset.pinned ? styles.presetIconBtnActive : styles.presetIconBtn}
+                      title="Pin to Daily Plan"
+                      aria-label={`Pin ${preset.name}`}
+                      aria-pressed={preset.pinned}
+                      onClick={() => updatePreset(i, { pinned: !preset.pinned })}
+                    >
+                      <svg
+                        width="12"
+                        height="12"
+                        viewBox="0 0 24 24"
+                        fill={preset.pinned ? 'currentColor' : 'none'}
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        aria-hidden="true"
+                      >
+                        <path d="M12 17v5" />
+                        <path d="M9 3h6l1 7 2.5 2.5H5.5L8 10z" />
+                      </svg>
+                    </button>
+                    <button
+                      type="button"
+                      className={
+                        props.editIndex === i ? styles.presetIconBtnActive : styles.presetIconBtn
+                      }
+                      style={{ marginRight: 6 }}
+                      title="Edit"
+                      aria-label={`Edit ${preset.name}`}
+                      onClick={() => props.setEditIndex(props.editIndex === i ? null : i)}
+                    >
+                      <svg
+                        width="12"
+                        height="12"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        aria-hidden="true"
+                      >
+                        <path d="M17 3a2.8 2.8 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5z" />
+                      </svg>
+                    </button>
+                  </div>
+                  {props.editIndex === i && (
+                    <div className={styles.presetEditor}>
+                      <input
+                        dir="auto"
+                        className={styles.smallInput}
+                        style={{ width: '100%', boxSizing: 'border-box', fontWeight: 600 }}
+                        value={preset.name}
+                        aria-label="Meal name"
+                        onChange={(e) => updatePreset(i, { name: e.target.value })}
+                      />
+                      <div className={styles.macroGrid}>
+                        {(
+                          [
+                            ['KCAL', 'cal'],
+                            ['P', 'p'],
+                            ['C', 'c'],
+                            ['F', 'f'],
+                          ] as const
+                        ).map(([label, field]) => (
+                          <label key={field} className={styles.macroLabel}>
+                            {label}
+                            <input
+                              type="number"
+                              className={styles.smallInput}
+                              style={{ width: '100%', boxSizing: 'border-box', padding: '5px 6px' }}
+                              value={preset[field]}
+                              onChange={(e) => updatePreset(i, { [field]: num(e.target.value) })}
+                            />
+                          </label>
+                        ))}
+                      </div>
+                      <button
+                        type="button"
+                        className={styles.dangerLink}
+                        onClick={() => {
+                          props.setEditIndex(null);
+                          props.patchSettings({
+                            presets: settings.presets.filter((_, j) => j !== i),
+                          });
+                        }}
+                      >
+                        DELETE MEAL
+                      </button>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+            {filtering && matches.length === 0 && (
+              <div className={styles.emptyHint}>
+                No saved meal matches “{query.trim()}”. Fill the macros above and tap Add, or start
+                one with “+ New saved meal”.
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </Modal>

--- a/apps/web/src/features/daily-plan/lib/meal-filter.test.ts
+++ b/apps/web/src/features/daily-plan/lib/meal-filter.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { filterMeals, scoreMeal } from './meal-filter';
+
+/** Saved-meal fuzzy search: forgiving substring/token/subsequence matching. */
+
+const meals = [
+  { name: 'My usual breakfast' },
+  { name: 'Chicken & rice bowl' },
+  { name: 'Protein shake + banana' },
+  { name: 'Cheeseburger' },
+  { name: 'سندوتش مفروم' },
+];
+
+describe('scoreMeal', () => {
+  it('substring match surfaces "burger" inside "Cheeseburger"', () => {
+    expect(scoreMeal('Cheeseburger', 'burger')).toBeGreaterThan(0);
+    // A non-substring word must not accidentally win over the real substring.
+    expect(scoreMeal('Cheeseburger', 'burger')).toBeGreaterThan(
+      scoreMeal('Chicken bowl', 'burger'),
+    );
+  });
+
+  it('ranks exact > prefix > interior substring', () => {
+    expect(scoreMeal('Cheeseburger', 'cheeseburger')).toBeGreaterThan(
+      scoreMeal('Cheeseburger', 'cheese'),
+    );
+    expect(scoreMeal('Cheeseburger', 'cheese')).toBeGreaterThan(
+      scoreMeal('Cheeseburger', 'burger'),
+    );
+  });
+
+  it('multi-token query matches when every token is present, any order', () => {
+    expect(scoreMeal('Chicken & rice bowl', 'chicken bowl')).toBeGreaterThan(0);
+    expect(scoreMeal('Chicken & rice bowl', 'bowl chicken')).toBeGreaterThan(0);
+  });
+
+  it('tolerates typos via subsequence (chikn → chicken)', () => {
+    expect(scoreMeal('Chicken & rice bowl', 'chikn')).toBeGreaterThan(0);
+  });
+
+  it('is Arabic-aware and diacritic-insensitive', () => {
+    expect(scoreMeal('سندوتش مفروم', 'مفروم')).toBeGreaterThan(0);
+    expect(scoreMeal('Café latte', 'cafe')).toBeGreaterThan(0);
+  });
+
+  it('rejects unrelated queries', () => {
+    expect(scoreMeal('Chicken & rice bowl', 'pizza')).toBe(0);
+    expect(scoreMeal('My usual breakfast', 'xyz')).toBe(0);
+  });
+
+  it('empty query is neutral (matches everything)', () => {
+    expect(scoreMeal('anything', '')).toBeGreaterThan(0);
+  });
+});
+
+describe('filterMeals', () => {
+  it('keeps original order and every item when query is blank', () => {
+    const out = filterMeals(meals, '  ');
+    expect(out.map((m) => m.item.name)).toEqual(meals.map((m) => m.name));
+    expect(out.map((m) => m.index)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('drops non-matches and preserves original indices for the survivors', () => {
+    const out = filterMeals(meals, 'burger');
+    expect(out).toHaveLength(1);
+    expect(out[0]?.item.name).toBe('Cheeseburger');
+    expect(out[0]?.index).toBe(3); // still points at the original position
+  });
+
+  it('sorts matches best-first', () => {
+    const shakes = [
+      { name: 'Banana shake' },
+      { name: 'Protein shake + banana' },
+      { name: 'Shake' },
+    ];
+    const out = filterMeals(shakes, 'shake');
+    expect(out[0]?.item.name).toBe('Shake'); // exact wins
+  });
+});

--- a/apps/web/src/features/daily-plan/lib/meal-filter.ts
+++ b/apps/web/src/features/daily-plan/lib/meal-filter.ts
@@ -1,0 +1,89 @@
+/**
+ * Fuzzy filtering for the Add Food popup's saved-meal search. Deliberately
+ * forgiving: the field doubles as the manual food-name input, so as the user
+ * types it should surface anything plausibly related, not only exact-word
+ * hits. "burger" must find "Cheeseburger" (substring), "chicken bowl" must
+ * find "Chicken & rice bowl" (all tokens present), and "chikn" should still
+ * reach "chicken" (subsequence, for typos). Works for Arabic names too —
+ * NFD strips Latin accents and Arabic harakat before matching.
+ */
+
+/** Combining marks: Latin diacritics (U+0300–036F) + Arabic harakat (U+064B–0652). */
+const COMBINING_MARKS = /[\u0300-\u036f\u064b-\u0652]/g;
+/** Anything that isn't a letter or number becomes a word gap. */
+const NON_WORD = /[^\p{L}\p{N}]+/gu;
+
+function normalize(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(COMBINING_MARKS, '')
+    .toLowerCase()
+    .replace(NON_WORD, ' ')
+    .trim();
+}
+
+/** True when every char of `query` appears in `text` in order (gaps allowed). */
+function isSubsequence(query: string, text: string): boolean {
+  if (query.length === 0) return true;
+  let qi = 0;
+  for (const ch of text) {
+    if (ch === query[qi]) qi += 1;
+    if (qi === query.length) return true;
+  }
+  return false;
+}
+
+/**
+ * 0 = no match. Higher = closer. An empty query returns a neutral 1 so the
+ * unfiltered list keeps its natural order.
+ */
+export function scoreMeal(name: string, query: string): number {
+  const q = normalize(query);
+  if (!q) return 1;
+  const n = normalize(name);
+  if (!n) return 0;
+
+  if (n === q) return 100;
+  if (n.startsWith(q)) return 90;
+  if (n.includes(q)) return 80; // "burger" inside "cheeseburger"
+
+  const tokens = q.split(' ').filter(Boolean);
+  if (tokens.length > 1 && tokens.every((token) => n.includes(token))) return 70;
+
+  const compactQ = q.replace(/ /g, '');
+  const compactN = n.replace(/ /g, '');
+  if (compactN.includes(compactQ)) return 60; // ignores spacing/punctuation
+
+  // Subsequence is the loosest tier — gate it to 3+ chars so a stray letter
+  // doesn't fuzzily match the whole list.
+  if (compactQ.length >= 3 && isSubsequence(compactQ, compactN)) return 40;
+
+  return 0;
+}
+
+export interface MealMatch<T> {
+  item: T;
+  /** Position in the ORIGINAL list — callers edit/pin/delete presets by it. */
+  index: number;
+  score: number;
+}
+
+/**
+ * Rank meals against a query. With no query the original order is preserved
+ * (every item kept); with a query, non-matches are dropped and matches sort
+ * best-first, ties broken by original position (stable).
+ */
+export function filterMeals<T extends { name: string }>(
+  meals: readonly T[],
+  query: string,
+): MealMatch<T>[] {
+  const scored = meals.map((item, index) => ({
+    item,
+    index,
+    score: scoreMeal(item.name, query),
+  }));
+  if (!query.trim()) return scored;
+  return scored
+    .filter((match) => match.score > 0)
+    .sort((a, b) => b.score - a.score || a.index - b.index);
+}


### PR DESCRIPTION
## Summary

Reorganizes the **Add Food** popup around the fast path, from on-device feedback:

- **Manual entry moves to the top** — the food-name + macro inputs lead, and the **Log to** slot chips now sit right beside the **ADD** button, so the target meal is picked at the moment of adding (instead of being a separate row at the very top).
- **Saved meals move below, in their own scroll region** — a long saved-meal list no longer pushes the Add button off-screen; the list caps at `min(46vh, 420px)` and scrolls with contained overscroll.
- **`+ New saved meal` is the first card** in the list instead of trailing it, and it **prefills its name from the food-name field** — so a search that finds nothing becomes the meal you were about to type.
- **The food-name field doubles as a fuzzy filter** over saved meals. Ranking, best-first: exact → prefix → substring (`burger` → **Cheeseburger**) → all-tokens-present (`chicken bowl` → **Chicken & rice bowl**) → subsequence for typos (`chikn` → **chicken**). Diacritic- and Arabic-aware (NFD strips Latin accents + harakat), so `مفروم` finds `سندوتش مفروم` and `cafe` finds `Café`. New `lib/meal-filter.ts` with 10 unit tests. Preset edit/pin/delete still key off the **original** list index, so filtering never mis-targets an edit.

**Verified in-browser** (390×844, guest): manual inputs render above the saved list; `+ New saved meal` is the first grid item; `ADD TO LUNCH` sits with the slot chips; typing `chicken bowl` narrows to Chicken & rice bowl; an unmatched query shows the empty-state hint; the saved list is a `max-height` `overflow:auto` region. Full web suite green (250 tests, incl. 10 new).

## Change Type
- [ ] Product behavior
- [ ] Feature scope
- [x] Frontend behavior
- [ ] Backend behavior
- [ ] API contract
- [ ] Data model
- [ ] Architecture
- [ ] Operations / deployment

## Documentation Impact
- [x] I evaluated documentation impact.
- [ ] I updated the relevant docs.
- [x] No docs update was needed, and I explained why below.

## Docs Updated

None.

## If no docs were updated, explain why

UI reorganization of the existing Add Food popup plus a client-side filter helper; no API, schema, or contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV)_