### PR TITLE
fix(web): stop iOS Safari zoom-on-focus by flooring input font-size at 16px

### DIFF
--- a/apps/web/src/shared/styles/globals.css
+++ b/apps/web/src/shared/styles/globals.css
@@ -43,6 +43,23 @@ textarea {
   color: inherit;
 }
 
+/*
+ * iOS Safari zooms the whole page in when a focused text field's font-size is
+ * below 16px — the layout jumps and you lose sight of what you're typing.
+ * Floor every text-entry control at 16px on touch pointers so tapping a field
+ * never rescales the page. Scale-aware (--plan-scale) so the A+ size setting
+ * still grows inputs past the floor; pinch-zoom stays available (no
+ * maximum-scale hack). Checkbox/radio/range have no text caret, so they never
+ * trigger the zoom and are left alone.
+ */
+@media (pointer: coarse) {
+  input:not([type='checkbox']):not([type='radio']):not([type='range']),
+  select,
+  textarea {
+    font-size: max(16px, calc(1rem * var(--plan-scale, 1)));
+  }
+}
+
 button {
   cursor: pointer;
   background: none;


### PR DESCRIPTION
## Summary

Field report (with screenshots): tapping the Arabic food-name field made iOS Safari zoom the whole page in, so the layout jumped and you couldn't see what you were typing. This is iOS Safari's well-known behavior — it auto-zooms whenever a focused text field's `font-size` is **below 16px**, and the plan's inputs run smaller (13px × scale).

Fix: a single `@media (pointer: coarse)` rule in `globals.css` floors every text-entry control — `input` (except checkbox/radio/range, which have no caret and never trigger it), `select`, `textarea` — at **16px**, the exact iOS threshold. It's scale-aware (`max(16px, calc(1rem * var(--plan-scale)))`) so the A+ size setting still grows inputs past the floor, and it deliberately avoids the `maximum-scale=1` / `user-scalable=no` hack so pinch-zoom stays available for accessibility.

Because it lives in `globals.css`, it cures the same zoom **app-wide** — the Add Task composer, the top-bar search, and Settings inputs — not just Add Food.

**Verified in-browser** (390×844, `pointer: coarse`): the Add Food inputs compute 17.92px (16 × the default 1.12 scale), all ≥ 16, and the five-column manual row still fits without overflow.

## Change Type
- [ ] Product behavior
- [ ] Feature scope
- [x] Frontend behavior
- [ ] Backend behavior
- [ ] API contract
- [ ] Data model
- [ ] Architecture
- [ ] Operations / deployment

## Documentation Impact
- [x] I evaluated documentation impact.
- [ ] I updated the relevant docs.
- [x] No docs update was needed, and I explained why below.

## Docs Updated

None.

## If no docs were updated, explain why

A single defensive CSS rule; no interface, API, or behavioral contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV)_