### PR TITLE
fix(web): lift bottom-sheet modals above the on-screen keyboard

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,10 @@
 <html lang="en" data-theme="paper">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
+    />
     <title>Lifeline</title>
     <meta name="description" content="Tasks + Daily Plan — discipline, focus, execution." />
     <link rel="manifest" href="/manifest.webmanifest" />

--- a/apps/web/src/features/daily-plan/ComposerModal.module.css
+++ b/apps/web/src/features/daily-plan/ComposerModal.module.css
@@ -21,12 +21,14 @@
 
 /* The sheet, not the overlay, scrolls — a scrollbar drag registers its
    mousedown here and never counts as an outside click. Bottom padding keeps
-   the submit row reachable above phone home-bars. */
+   the submit row reachable above phone home-bars. --kb-inset trims the height
+   to the visible band so a focused field never hides behind the keyboard. */
 .sheet {
   width: min(680px, 100%);
-  max-height: 100dvh;
+  max-height: calc(100dvh - var(--kb-inset, 0px));
   overflow-y: auto;
-  padding: var(--space-12) var(--space-16) calc(var(--space-24) + env(safe-area-inset-bottom, 0px));
+  padding: var(--space-12) var(--space-16)
+    calc(var(--space-24) + env(safe-area-inset-bottom, 0px) + var(--kb-inset, 0px));
 }
 
 /* Cancel affordance: rides sticky at the top of the scrolling sheet so it

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,8 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './app/App';
+import { installKeyboardInsetTracking } from './shared/lib/keyboard-inset';
 import './shared/styles/tokens.css';
 import './shared/styles/globals.css';
+
+// Publish the on-screen keyboard's height as --kb-inset so bottom-sheet modals
+// can lift their inputs above it (iOS Safari overlays the keyboard).
+installKeyboardInsetTracking();
 
 const container = document.getElementById('root');
 if (!container) throw new Error('Missing #root element');

--- a/apps/web/src/shared/lib/keyboard-inset.test.ts
+++ b/apps/web/src/shared/lib/keyboard-inset.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { computeKeyboardInset } from './keyboard-inset';
+
+/** Keyboard-overlap math for lifting bottom sheets above the iOS keyboard. */
+
+describe('computeKeyboardInset', () => {
+  it('is 0 when the visual viewport fills the layout viewport (no keyboard)', () => {
+    expect(computeKeyboardInset(844, { height: 844, offsetTop: 0 })).toBe(0);
+  });
+
+  it('ignores small gaps (URL-bar jitter, not a keyboard)', () => {
+    expect(computeKeyboardInset(844, { height: 800, offsetTop: 0 })).toBe(0);
+  });
+
+  it('reports the keyboard height when the viewport shrinks', () => {
+    // 844 layout, keyboard ~336px → visible 508.
+    expect(computeKeyboardInset(844, { height: 508, offsetTop: 0 })).toBe(336);
+  });
+
+  it('accounts for visual-viewport scroll offset', () => {
+    expect(computeKeyboardInset(844, { height: 500, offsetTop: 44 })).toBe(300);
+  });
+
+  it('never returns a negative inset', () => {
+    expect(computeKeyboardInset(844, { height: 900, offsetTop: 0 })).toBe(0);
+  });
+});

--- a/apps/web/src/shared/lib/keyboard-inset.ts
+++ b/apps/web/src/shared/lib/keyboard-inset.ts
@@ -1,0 +1,60 @@
+/**
+ * On-screen keyboard tracking for bottom-sheet modals.
+ *
+ * iOS Safari overlays the software keyboard WITHOUT shrinking the layout
+ * viewport — `100vh`/`100dvh` and a `position: fixed; bottom: 0` sheet stay
+ * anchored to the full-height viewport, so the sheet's lower half (its input
+ * row and buttons) ends up hidden behind the keyboard. `visualViewport` is
+ * the only surface that reflects the keyboard, so we translate its state into
+ * a `--kb-inset` custom property on :root that the modal CSS subtracts to lift
+ * content above the keyboard. On Android Chrome the keyboard resizes the
+ * viewport (with `interactive-widget=resizes-content`), so the inset stays ~0
+ * there and `dvh` does the work — the two mechanisms compose without
+ * double-counting.
+ */
+
+/** Below this many px the gap is URL-bar jitter, not a keyboard. */
+const KEYBOARD_MIN_PX = 80;
+
+/**
+ * Bottom overlap (px) between the visible viewport and the layout viewport —
+ * i.e. how much of the page the keyboard is covering. 0 when no keyboard.
+ * Exported for unit testing; callers use the installed tracker below.
+ */
+export function computeKeyboardInset(
+  innerHeight: number,
+  viewport: { height: number; offsetTop: number },
+): number {
+  const overlap = innerHeight - viewport.height - viewport.offsetTop;
+  return overlap > KEYBOARD_MIN_PX ? Math.round(overlap) : 0;
+}
+
+let installed = false;
+
+/** Idempotently start writing --kb-inset on :root. Safe to call once at boot. */
+export function installKeyboardInsetTracking(): () => void {
+  if (installed || typeof window === 'undefined') return () => {};
+  const vv = window.visualViewport;
+  if (!vv) return () => {};
+  installed = true;
+
+  const root = document.documentElement;
+  const update = () => {
+    const inset = computeKeyboardInset(window.innerHeight, {
+      height: vv.height,
+      offsetTop: vv.offsetTop,
+    });
+    root.style.setProperty('--kb-inset', `${inset}px`);
+  };
+
+  vv.addEventListener('resize', update);
+  vv.addEventListener('scroll', update);
+  update();
+
+  return () => {
+    vv.removeEventListener('resize', update);
+    vv.removeEventListener('scroll', update);
+    root.style.removeProperty('--kb-inset');
+    installed = false;
+  };
+}

--- a/apps/web/src/shared/ui/Modal.module.css
+++ b/apps/web/src/shared/ui/Modal.module.css
@@ -46,14 +46,19 @@
    the dynamic viewport (Safari's collapsing URL bar), padded past the home
    bar, with a grabber so it reads as sheet UI. Desktop stays a card. */
 @media (max-width: 640px) {
+  /* --kb-inset (from keyboard-inset.ts) is the on-screen keyboard height.
+     Padding-bottom lifts the sheet's anchor above the keyboard; the modal's
+     max-height then fits it into the remaining visible band, so a focused
+     input never hides behind the keyboard on iOS. */
   .overlay {
     align-items: flex-end;
-    padding: var(--space-24) 0 0;
+    padding: var(--space-24) 0 var(--kb-inset, 0px);
+    transition: padding-bottom 0.2s ease;
   }
 
   .overlay .modal {
     width: 100%;
-    max-height: calc(100dvh - 40px);
+    max-height: calc(100dvh - 40px - var(--kb-inset, 0px));
     border-bottom: none;
     border-radius: var(--border-radius-large) var(--border-radius-large) 0 0;
     animation: sheet-up 0.28s cubic-bezier(0.32, 0.72, 0.22, 1);


### PR DESCRIPTION
## Summary

Field report (with screenshots): in Add Food, once the keyboard is up, the input row and buttons hide behind it — typing a food that isn't saved dropped the list and pushed everything under the keys, so you couldn't see what you were typing. Root cause: **iOS Safari overlays the software keyboard without shrinking the layout viewport**, so `100dvh`/`vh` don't account for it and a `position: fixed; bottom: 0` sheet keeps its lower half behind the keyboard.

Fix, using the only API that reflects the keyboard on iOS — `window.visualViewport`:

- **`keyboard-inset.ts`** installs a singleton `visualViewport` listener at boot that publishes the keyboard's overlap height as `--kb-inset` on `:root` (0 when no keyboard; ignores sub-80px URL-bar jitter). Pure inset math is unit-tested (5 cases).
- **Shared `Modal`** (Add Food, Plan Settings, Settings) on ≤640px lifts its anchor by `--kb-inset` (overlay `padding-bottom`) and caps `max-height` to the visible band, so the sheet sits above the keyboard with a focused field in view.
- **`ComposerModal`** (Add Task, top-anchored) trims `max-height` and bottom padding by the same inset.
- **Viewport meta** gains `interactive-widget=resizes-content` so Android Chrome resizes the viewport natively — there `--kb-inset` stays ~0 and `dvh` does the work; the two compose without double-counting.

Pinch-zoom stays available (no `user-scalable=no`), and desktop centered-card modals are untouched (the inset lives only inside the ≤640px blocks).

**Verified in-browser** (390×844, touch): with no keyboard the Add Food sheet spans to the viewport bottom (844); injecting a 336px `--kb-inset` (what `visualViewport` reports on a real keyboard) lifts the sheet's bottom to 508 (the keyboard's top edge), shrinks its height to 468, and the food-name field sits at y=191 — fully clear of the keyboard. Full web suite green (255, incl. 5 new).

## Change Type
- [ ] Product behavior
- [ ] Feature scope
- [x] Frontend behavior
- [ ] Backend behavior
- [ ] API contract
- [ ] Data model
- [ ] Architecture
- [ ] Operations / deployment

## Documentation Impact
- [x] I evaluated documentation impact.
- [ ] I updated the relevant docs.
- [x] No docs update was needed, and I explained why below.

## Docs Updated

None.

## If no docs were updated, explain why

Client-side viewport/keyboard handling for existing modals; no API, schema, or contract surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV)_