### PR TITLE
feat(plan): carry-over confirmation toast + per-task Move to (Today/Tomorrow/date)

### DIFF
--- a/apps/web/src/features/daily-plan/DailyPlan.module.css
+++ b/apps/web/src/features/daily-plan/DailyPlan.module.css
@@ -530,6 +530,48 @@ button.weekChipToday:hover:not(:disabled) {
   flex-direction: column;
 }
 
+/* Transient confirmation toast (carry-over, task move) — fixed near the top
+   so it's seen even when the affected card is scrolled away or hidden. */
+.planToast {
+  position: fixed;
+  top: calc(12px + env(safe-area-inset-top, 0px));
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 940;
+  max-width: min(88vw, 420px);
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: var(--plan-secbar);
+  color: var(--plan-secbar-text);
+  border: 1px solid var(--plan-card-border);
+  font-family: var(--plan-label-font);
+  font-size: calc(11px * var(--plan-scale, 1));
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-align: center;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.32);
+  animation: planToastIn 0.22s ease-out;
+}
+
+@media (min-width: 769px) {
+  .planToast {
+    left: calc(50% + var(--sidebar-width) / 2);
+  }
+}
+
+@keyframes planToastIn {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(-8px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .planToast {
+    animation: none;
+  }
+}
+
 /* ── jump navigation & internal list scrolling ───────────────────────────── */
 
 /* Jump targets stop clear of the sticky top bar. */

--- a/apps/web/src/features/daily-plan/DailyPlanView.tsx
+++ b/apps/web/src/features/daily-plan/DailyPlanView.tsx
@@ -1,10 +1,16 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, ReactElement } from 'react';
+import { format, parseISO } from 'date-fns';
 import type { DailyPlanData, DailyPlanSettings, HabitMark, Tag, Todo } from '@lifeline/shared';
 import { MEAL_SLOTS, bmr, dayBalance, maintenanceBase, proposeTarget } from '@lifeline/shared';
 import { useTheme } from '../../app/providers/theme-context';
 import { filterTodosForDay, resolveDayString } from '../todos/lib/day-filter';
-import { useCreateTodo, useToggleComplete, useUpdateSubtasks } from '../todos/data/hooks';
+import {
+  useCreateTodo,
+  useToggleComplete,
+  useUpdateSubtasks,
+  useUpdateTodo,
+} from '../todos/data/hooks';
 import {
   useDailyPlanWeek,
   usePlanSaveStatus,
@@ -262,6 +268,16 @@ export function DailyPlanView({
   const isToday = dateStr === resolveDayString('today');
   const carry = useMemo(() => carryOverFrom(yesterday), [yesterday]);
   const [carryError, setCarryError] = useState(false);
+
+  // Transient confirmation toast for actions whose result lands off-screen
+  // (carry-over creates tasks in the To-Do card; a move re-dates a task off
+  // the current day) — otherwise those read as "nothing happened".
+  const [toast, setToast] = useState<string | null>(null);
+  useEffect(() => {
+    if (!toast) return;
+    const timer = setTimeout(() => setToast(null), 2600);
+    return () => clearTimeout(timer);
+  }, [toast]);
   const addCarryAsTasks = useCallback(() => {
     const existing = new Set(
       filterTodosForDay(todos, dateStr).map((t) => t.title.trim().toLowerCase()),
@@ -287,14 +303,40 @@ export function DailyPlanView({
       );
     }
     setCarryError(false);
+    const added = creates.length;
     void Promise.allSettled(creates).then((results) => {
       // Don't burn the one-shot offer if every create failed (offline etc.).
       if (results.some((r) => r.status === 'rejected')) setCarryError(true);
-      if (creates.length === 0 || results.some((r) => r.status === 'fulfilled')) {
+      if (added === 0 || results.some((r) => r.status === 'fulfilled')) {
         patchDay({ carryHandled: true });
+        // The new tasks land in the To-Do card (which may be scrolled away or
+        // hidden), so confirm the outcome explicitly.
+        setToast(
+          added === 0 ? 'Those tasks are already on today' : `Moved ${added} to today's tasks`,
+        );
       }
     });
   }, [carry, todos, createTodo, dateStr, patchDay]);
+
+  // Per-task reschedule from the preview popup (Today / Tomorrow / pick a date).
+  const updateTodo = useUpdateTodo();
+  const moveTask = useCallback(
+    (todo: Todo, targetDate: string) => {
+      if (todo.dueDate === targetDate) return;
+      updateTodo.mutate({ id: todo.id, patch: { dueDate: targetDate } });
+      setPreviewId(null);
+      const today = resolveDayString('today');
+      const tomorrow = daysAfter(today, 1);
+      const label =
+        targetDate === today
+          ? 'today'
+          : targetDate === tomorrow
+            ? 'tomorrow'
+            : format(parseISO(targetDate), 'EEE, MMM d');
+      setToast(`Moved “${todo.title}” to ${label}`);
+    },
+    [updateTodo, setPreviewId, setToast],
+  );
 
   // Personal suggestion pools from the last 28 days.
   const prioSugs = useMemo(() => prioritySuggestions(recentDays), [recentDays]);
@@ -1124,7 +1166,14 @@ export function DailyPlanView({
           setPreviewId(null);
           openTask(todo, todo.dueDate ?? dateStr);
         }}
+        onMove={moveTask}
       />
+
+      {toast && (
+        <div className={styles.planToast} role="status" aria-live="polite">
+          {toast}
+        </div>
+      )}
 
       <JumpSheet sections={jumpSections} onReorder={reorderVisible} />
     </div>

--- a/apps/web/src/features/daily-plan/TaskPreviewModal.module.css
+++ b/apps/web/src/features/daily-plan/TaskPreviewModal.module.css
@@ -265,6 +265,77 @@
   text-decoration: line-through;
 }
 
+/* ── move-to (reschedule) ────────────────────────────────────────────────── */
+
+.moveRow {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-8);
+  padding-top: var(--space-10);
+  border-top: 1px solid var(--color-border);
+}
+
+.moveLabel {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+}
+
+.moveBtn {
+  padding: var(--space-6) var(--space-12);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--color-text);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.moveBtn:hover:not(:disabled),
+.moveBtn:focus-visible {
+  border-color: var(--color-primary);
+  background: var(--color-surface-light);
+}
+
+.moveBtn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+/* "Pick a date" — the whole chip is the label so tapping anywhere opens the
+   native picker; the input carries the value and fires onChange. */
+.moveDate {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-6);
+  padding: var(--space-6) var(--space-10);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+.moveDate:hover,
+.moveDate:focus-within {
+  border-color: var(--color-primary);
+  color: var(--color-text);
+}
+
+.moveDate input {
+  border: none;
+  background: transparent;
+  color: var(--color-text);
+  font: inherit;
+  cursor: pointer;
+  width: 1.2rem; /* just the picker icon; the label carries the text */
+}
+
 /* ── footer ──────────────────────────────────────────────────────────────── */
 
 .footer {

--- a/apps/web/src/features/daily-plan/TaskPreviewModal.tsx
+++ b/apps/web/src/features/daily-plan/TaskPreviewModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { format, parseISO } from 'date-fns';
+import { addDays, format, parseISO } from 'date-fns';
 import type { Todo } from '@lifeline/shared';
 import { SquareCheck } from './cards';
 import styles from './TaskPreviewModal.module.css';
@@ -45,6 +45,8 @@ export interface TaskPreviewModalProps {
   onToggleSubtask: (todo: Todo, subtaskId: string) => void;
   /** Hand off to the full Tasks editor. */
   onEdit: (todo: Todo) => void;
+  /** Reschedule the task's due date ('YYYY-MM-DD'). */
+  onMove?: ((todo: Todo, dateStr: string) => void) | undefined;
 }
 
 export function TaskPreviewModal({
@@ -53,6 +55,7 @@ export function TaskPreviewModal({
   onToggleComplete,
   onToggleSubtask,
   onEdit,
+  onMove,
 }: TaskPreviewModalProps) {
   const open = todo !== null;
   useEffect(() => {
@@ -77,6 +80,9 @@ export function TaskPreviewModal({
   const meta = [formatDate(todo.dueDate), todo.dueTime, formatDuration(todo.duration)].filter(
     Boolean,
   );
+  const now = new Date();
+  const todayStr = format(now, 'yyyy-MM-dd');
+  const tomorrowStr = format(addDays(now, 1), 'yyyy-MM-dd');
 
   return createPortal(
     <div
@@ -167,6 +173,39 @@ export function TaskPreviewModal({
                 </li>
               ))}
             </ul>
+          </div>
+        )}
+
+        {onMove && (
+          <div className={styles.moveRow}>
+            <span className={styles.moveLabel}>Move to</span>
+            <button
+              type="button"
+              className={styles.moveBtn}
+              disabled={todo.dueDate === todayStr}
+              onClick={() => onMove(todo, todayStr)}
+            >
+              Today
+            </button>
+            <button
+              type="button"
+              className={styles.moveBtn}
+              disabled={todo.dueDate === tomorrowStr}
+              onClick={() => onMove(todo, tomorrowStr)}
+            >
+              Tomorrow
+            </button>
+            <label className={styles.moveDate}>
+              <span>Pick a date</span>
+              <input
+                type="date"
+                aria-label="Move task to a specific date"
+                value={todo.dueDate ?? ''}
+                onChange={(event) => {
+                  if (event.target.value) onMove(todo, event.target.value);
+                }}
+              />
+            </label>
           </div>
         )}
 

--- a/apps/web/src/features/daily-plan/daily-plan-personalize.test.tsx
+++ b/apps/web/src/features/daily-plan/daily-plan-personalize.test.tsx
@@ -122,6 +122,9 @@ describe('day continuity', () => {
 
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: 'Add as tasks' }));
+    // A toast confirms the outcome (the tasks land in the To-Do card, which
+    // may be scrolled away or hidden — so the action needs explicit feedback).
+    expect(await screen.findByText(/Moved 2 to today's tasks/)).toBeInTheDocument();
     // Both carried items became REAL guest tasks due today.
     await waitFor(() => {
       const raw = window.localStorage.getItem('guest_todos');

--- a/apps/web/src/features/daily-plan/daily-plan-tasks.test.tsx
+++ b/apps/web/src/features/daily-plan/daily-plan-tasks.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { addDays, format } from 'date-fns';
 import type { Todo } from '@lifeline/shared';
 import { ThemeProvider } from '../../app/providers/theme-provider';
 import { renderWithProviders } from '../../test/harness';
@@ -69,6 +70,45 @@ describe('To-Do card', () => {
     // Completed task title stays plain text (no preview link).
     expect(screen.queryByRole('button', { name: 'Old chore' })).not.toBeInTheDocument();
     expect(screen.getByText('Old chore')).toBeInTheDocument();
+  });
+
+  it('preview → Move to a specific date reschedules the task and confirms with a toast', async () => {
+    const task = makeTodo({ title: 'Ship report', dueDate: '2026-07-09' });
+    renderPlan([task]);
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole('button', { name: 'Ship report' }));
+    const dialog = await screen.findByRole('dialog', { name: /Task/ });
+    // Native date inputs don't take userEvent typing well — fire the change.
+    fireEvent.change(within(dialog).getByLabelText('Move task to a specific date'), {
+      target: { value: '2026-07-12' },
+    });
+
+    await waitFor(() => {
+      const raw = window.localStorage.getItem('guest_todos');
+      const todos = JSON.parse(raw as string) as { id: string; dueDate: string | null }[];
+      expect(todos.find((t) => t.id === task.id)?.dueDate).toBe('2026-07-12');
+    });
+    // Preview closes and a toast confirms the move (the task left this day's list).
+    expect(screen.queryByRole('dialog', { name: /Task/ })).not.toBeInTheDocument();
+    expect(await screen.findByText(/Moved .*Ship report.* to/)).toBeInTheDocument();
+  });
+
+  it('preview → Tomorrow re-dates the task to the next day', async () => {
+    const task = makeTodo({ title: 'Ship report', dueDate: '2026-07-09' });
+    renderPlan([task]);
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole('button', { name: 'Ship report' }));
+    const dialog = await screen.findByRole('dialog', { name: /Task/ });
+    await user.click(within(dialog).getByRole('button', { name: 'Tomorrow' }));
+
+    const tomorrow = format(addDays(new Date(), 1), 'yyyy-MM-dd');
+    await waitFor(() => {
+      const raw = window.localStorage.getItem('guest_todos');
+      const todos = JSON.parse(raw as string) as { id: string; dueDate: string | null }[];
+      expect(todos.find((t) => t.id === task.id)?.dueDate).toBe(tomorrow);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Two task-moving gaps, from field feedback:

**1. "Add as tasks" (carry yesterday's unfinished items) looked like it did nothing.** It actually worked — the items became real tasks due today — but the carry bar vanished at the top of the page while the new tasks landed in the To-Do card lower down (or nowhere visible, if that card was hidden), so there was no perceptible result. It now fires a **confirmation toast** (`Moved N to today's tasks`), so the outcome is always seen. (Repro confirmed in-browser: the tasks *were* created; the miss was purely feedback.)

**2. No way to reschedule a single task from the plan.** The task-preview popup (tap any task on Schedule / To-Do / Priorities / Tomorrow) gains a **"Move to" row** — **Today**, **Tomorrow**, and **Pick a date** (native date picker) — that updates the task's `dueDate` via `useUpdateTodo`, closes the preview, and confirms with the same toast. The current day's own button is disabled so it's never a no-op.

A shared transient toast (fixed near the top, theme-aware via `--plan-*`, `--plan-scale`-aware, reduced-motion safe) drives both.

**Verified in-browser** (390×844, guest): opening a today-task shows Move-to with Today disabled; tapping Tomorrow re-dates it to the next day, shows the toast, and closes the preview; the carry bar now toasts on add. Full web suite green (257, incl. new move + carry-toast tests).

## Change Type
- [ ] Product behavior
- [x] Feature scope
- [x] Frontend behavior
- [ ] Backend behavior
- [ ] API contract
- [ ] Data model
- [ ] Architecture
- [ ] Operations / deployment

## Documentation Impact
- [x] I evaluated documentation impact.
- [ ] I updated the relevant docs.
- [x] No docs update was needed, and I explained why below.

## Docs Updated

None.

## If no docs were updated, explain why

UI additions over existing tasks/plan data (`dueDate` via the existing update endpoint); no API, schema, or contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV)_