### PR TITLE
feat(plan): prayer times by city on the five salah habit rows

### DIFF
--- a/apps/server/src/http/app.test.ts
+++ b/apps/server/src/http/app.test.ts
@@ -201,4 +201,10 @@ describe('createApp CSP lets the SPA reach Auth0', () => {
     expect(csp).toMatch(/font-src[^;]*https:\/\/fonts\.gstatic\.com/);
     expect(csp).toMatch(/img-src[^;]*https:/);
   });
+
+  it('allows the Aladhan prayer-times API in connect-src (browser-direct fetch)', async () => {
+    const response = await request(app).get('/api/v1/info');
+    const csp = response.headers['content-security-policy'] ?? '';
+    expect(csp).toMatch(/connect-src[^;]*https:\/\/api\.aladhan\.com/);
+  });
 });

--- a/apps/server/src/http/app.ts
+++ b/apps/server/src/http/app.ts
@@ -88,7 +88,8 @@ export function createApp(container: Container): Express {
           'style-src': ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
           'font-src': ["'self'", 'https://fonts.gstatic.com', 'data:'],
           'img-src': ["'self'", 'data:', 'https:'],
-          'connect-src': ["'self'", ...auth0Sources],
+          // Aladhan supplies prayer times by city (browser-direct fetch).
+          'connect-src': ["'self'", 'https://api.aladhan.com', ...auth0Sources],
           'frame-src': ["'self'", ...auth0Sources],
         },
       },

--- a/apps/web/src/app/pages/OnboardingPage.tsx
+++ b/apps/web/src/app/pages/OnboardingPage.tsx
@@ -33,6 +33,7 @@ export default function OnboardingPage() {
   const [email, setEmail] = useState(currentUser?.email ?? '');
   const [phone, setPhone] = useState('');
   const [country, setCountry] = useState('');
+  const [city, setCity] = useState('');
   const [startDay, setStartDay] = useState<DayName>('Monday');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
@@ -64,6 +65,7 @@ export default function OnboardingPage() {
         timezone: getBrowserTimezone(),
         phone: phone.trim() || null,
         country: country.trim() || null,
+        city: city.trim() || null,
         startDayOfWeek: startDay,
         onboardingCompleted: true,
       });
@@ -155,6 +157,19 @@ export default function OnboardingPage() {
               className={styles.input}
               value={country}
               onChange={(event) => handleCountryChange(event.target.value)}
+            />
+          </div>
+
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="onboarding-city">
+              City
+            </label>
+            <input
+              id="onboarding-city"
+              className={styles.input}
+              value={city}
+              placeholder="For accurate prayer times"
+              onChange={(event) => setCity(event.target.value)}
             />
           </div>
 

--- a/apps/web/src/app/pages/onboarding.test.tsx
+++ b/apps/web/src/app/pages/onboarding.test.tsx
@@ -62,6 +62,8 @@ describe('OnboardingPage', () => {
 
     await user.type(screen.getByLabelText('First Name *'), 'Ziyad');
     await user.type(screen.getByLabelText('Last Name *'), 'Salem');
+    // City feeds prayer times downstream — it must reach the profile PUT.
+    await user.type(screen.getByLabelText('City'), 'Cairo');
     // Email is prefilled from the identity.
     await user.click(screen.getByRole('button', { name: 'Continue' }));
 
@@ -74,6 +76,7 @@ describe('OnboardingPage', () => {
       firstName: 'Ziyad',
       lastName: 'Salem',
       email: 'ziyad@example.com',
+      city: 'Cairo',
       startDayOfWeek: 'Monday',
       onboardingCompleted: true,
     });

--- a/apps/web/src/features/daily-plan/DailyPlan.module.css
+++ b/apps/web/src/features/daily-plan/DailyPlan.module.css
@@ -985,6 +985,25 @@ button.weekChipToday:hover:not(:disabled) {
   vertical-align: 1px;
 }
 
+/* Prayer time next to a salah habit's label — quiet, monospaced digits. */
+.prayerTimeBadge {
+  margin-inline-start: 6px;
+  font-size: calc(9.5px * var(--plan-scale, 1));
+  font-weight: 600;
+  color: var(--plan-muted);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  vertical-align: 1px;
+}
+
+/* Shown under the habit grid when no city is set yet. */
+.prayerHint {
+  margin: 8px 0 0;
+  font-size: calc(10px * var(--plan-scale, 1));
+  color: var(--plan-muted);
+  font-style: italic;
+}
+
 /* 28 squares, oldest → newest (GitHub-graph style, monochrome). */
 .habitHistory {
   display: grid;

--- a/apps/web/src/features/daily-plan/DailyPlanView.tsx
+++ b/apps/web/src/features/daily-plan/DailyPlanView.tsx
@@ -4,6 +4,7 @@ import { format, parseISO } from 'date-fns';
 import type { DailyPlanData, DailyPlanSettings, HabitMark, Tag, Todo } from '@lifeline/shared';
 import { MEAL_SLOTS, bmr, dayBalance, maintenanceBase, proposeTarget } from '@lifeline/shared';
 import { useTheme } from '../../app/providers/theme-context';
+import { useAuth } from '../../app/providers/auth-context';
 import { filterTodosForDay, resolveDayString } from '../todos/lib/day-filter';
 import {
   useCreateTodo,
@@ -20,6 +21,7 @@ import {
   useSaveSettings,
   type PlanSaveStatus,
 } from './data/hooks';
+import { usePrayerTimes } from './data/prayer-hooks';
 import {
   PLAN_GRID_KEYS,
   PLAN_SECTIONS,
@@ -195,6 +197,32 @@ export function DailyPlanView({
       saveSettings(next);
     },
     [saveSettings],
+  );
+
+  // Prayer times: seed the plan's prayer city from the account profile once
+  // (an onboarding-only user gets times without re-entering their city), then
+  // fetch the selected day's five times. Editing the city in Customize wins.
+  const { currentUser } = useAuth();
+  const prayer = settings.prayer;
+  useEffect(() => {
+    if (!settingsReady) return;
+    if (prayer.city.trim()) return; // already set — don't clobber a Customize edit
+    const profileCity = currentUser?.profile?.city?.trim();
+    if (!profileCity) return;
+    patchSettings({
+      prayer: {
+        ...settingsRef.current.prayer,
+        city: profileCity,
+        country: currentUser?.profile?.country?.trim() ?? settingsRef.current.prayer.country,
+      },
+    });
+  }, [settingsReady, prayer.city, currentUser, patchSettings]);
+
+  const { times: prayerTimes, active: prayerActive } = usePrayerTimes(
+    prayer.enabled ? prayer.city : '',
+    prayer.country,
+    prayer.method,
+    dateStr,
   );
 
   const day = effectiveDays[dateStr] ?? materialized;
@@ -753,6 +781,8 @@ export function DailyPlanView({
           onEditHabits={(updater) => patchSettings((s) => ({ habits: updater(s.habits) }))}
           streaks={streaks}
           historyFor={historyFor}
+          prayerTimes={prayerTimes}
+          prayerActive={prayerActive}
         />
       ),
     },

--- a/apps/web/src/features/daily-plan/PlanSettingsModal.tsx
+++ b/apps/web/src/features/daily-plan/PlanSettingsModal.tsx
@@ -274,6 +274,112 @@ function BodyGoalSection(props: {
   );
 }
 
+/** Aladhan calculation methods. -1 = Auto (let the API pick for the city). */
+const PRAYER_METHODS: { value: number; label: string }[] = [
+  { value: -1, label: 'Auto — best for your city' },
+  { value: 3, label: 'Muslim World League' },
+  { value: 2, label: 'ISNA — North America' },
+  { value: 4, label: 'Umm al-Qura — Makkah' },
+  { value: 5, label: 'Egyptian General Authority' },
+  { value: 1, label: 'Univ. of Islamic Sciences, Karachi' },
+  { value: 7, label: 'Univ. of Tehran' },
+  { value: 0, label: 'Shia Ithna-Ashari — Jafari' },
+  { value: 8, label: 'Gulf Region' },
+  { value: 9, label: 'Kuwait' },
+  { value: 10, label: 'Qatar' },
+  { value: 11, label: 'Singapore' },
+  { value: 13, label: 'Turkey — Diyanet' },
+];
+
+/**
+ * PRAYER TIMES: type a city (+ country) to show accurate times on the five
+ * salah habit rows. Auto lets the provider pick the closest authority for the
+ * location; the Advanced disclosure overrides it with a specific method.
+ */
+function PrayerSection(props: {
+  settings: DailyPlanSettings;
+  patchSettings: (patch: Partial<DailyPlanSettings>) => void;
+}) {
+  const prayer = props.settings.prayer;
+  const [showAdvanced, setShowAdvanced] = useState(prayer.method >= 0);
+  const patchPrayer = (patch: Partial<DailyPlanSettings['prayer']>) =>
+    props.patchSettings({ prayer: { ...prayer, ...patch } });
+  const wordLabel = { fontSize: 'calc(9px * var(--plan-scale, 1))' } as const;
+  const fullWidth = { width: '100%', boxSizing: 'border-box' } as const;
+
+  return (
+    <Section title="Prayer times — shown on the five salah rows">
+      <div className={styles.macroGrid} style={{ gridTemplateColumns: 'repeat(2, 1fr)' }}>
+        <label className={styles.macroLabel} style={wordLabel}>
+          CITY
+          <input
+            dir="auto"
+            className={styles.smallInput}
+            style={fullWidth}
+            maxLength={120}
+            placeholder="e.g. Cairo"
+            value={prayer.city}
+            aria-label="Prayer city"
+            onChange={(e) => patchPrayer({ city: e.target.value })}
+          />
+        </label>
+        <label className={styles.macroLabel} style={wordLabel}>
+          COUNTRY
+          <input
+            dir="auto"
+            className={styles.smallInput}
+            style={fullWidth}
+            maxLength={120}
+            placeholder="e.g. Egypt"
+            value={prayer.country}
+            aria-label="Prayer country"
+            onChange={(e) => patchPrayer({ country: e.target.value })}
+          />
+        </label>
+      </div>
+      <label
+        className={styles.macroLabel}
+        style={{ flexDirection: 'row', alignItems: 'center', gap: 8, ...wordLabel }}
+      >
+        <input
+          type="checkbox"
+          checked={prayer.enabled}
+          aria-label="Show prayer times on the salah rows"
+          onChange={(e) => patchPrayer({ enabled: e.target.checked })}
+        />
+        SHOW TIMES ON THE SALAH ROWS
+      </label>
+      <button
+        type="button"
+        className={styles.habitLabelBtn}
+        style={{ alignSelf: 'flex-start', ...wordLabel, color: 'var(--plan-muted)' }}
+        aria-expanded={showAdvanced}
+        onClick={() => setShowAdvanced((v) => !v)}
+      >
+        {showAdvanced ? '▾ ' : '▸ '}ADVANCED — CALCULATION METHOD
+      </button>
+      {showAdvanced && (
+        <label className={styles.macroLabel} style={wordLabel}>
+          CALCULATION METHOD
+          <select
+            className={styles.smallInput}
+            style={fullWidth}
+            value={prayer.method}
+            aria-label="Prayer calculation method"
+            onChange={(e) => patchPrayer({ method: Number.parseInt(e.target.value, 10) })}
+          >
+            {PRAYER_METHODS.map((m) => (
+              <option key={m.value} value={m.value}>
+                {m.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+    </Section>
+  );
+}
+
 export function PlanSettingsModal(props: PlanSettingsModalProps) {
   const { settings } = props;
   const [templateKey, setTemplateKey] = useState<TemplateKey>(templateKeyOf(props.dateStr));
@@ -517,6 +623,8 @@ export function PlanSettingsModal(props: PlanSettingsModalProps) {
           weightKg={props.weightKg}
           fatPct={props.fatPct}
         />
+
+        <PrayerSection settings={settings} patchSettings={props.patchSettings} />
 
         <Section title="Schedule & rows">
           <div className={styles.macroGrid}>

--- a/apps/web/src/features/daily-plan/cards.tsx
+++ b/apps/web/src/features/daily-plan/cards.tsx
@@ -20,6 +20,7 @@ import {
   toLengthDisplay,
   toWeightDisplay,
 } from './lib/units';
+import { PRAYER_HABIT_IDS, type DayPrayers, type PrayerKey } from './lib/prayer-times';
 import styles from './DailyPlan.module.css';
 
 /**
@@ -638,7 +639,14 @@ export interface HabitsBodyProps {
   streaks: Record<string, number>;
   /** 28-day history per habit id, oldest → newest (label click reveals it). */
   historyFor: (habitId: string) => { date: string; mark: HabitMark | undefined }[];
+  /** The selected day's five prayer times (by city), or null when unavailable. */
+  prayerTimes?: DayPrayers | null;
+  /** Prayer feature is on (a city is set) — gates the empty-city hint. */
+  prayerActive?: boolean;
 }
+
+/** Fixed prayer-habit ids, for a quick "is this a timed salah" membership test. */
+const PRAYER_ID_SET = new Set<string>(PRAYER_HABIT_IDS);
 
 /** empty → done → skipped → empty. */
 function nextHabitMark(current: HabitMark | undefined): HabitMark {
@@ -680,6 +688,8 @@ function HabitTrackerRow(props: {
   onMark: (date: string, habitId: string, next: HabitMark) => void;
   streak: number;
   historyFor: (habitId: string) => { date: string; mark: HabitMark | undefined }[];
+  /** HH:MM prayer time to show next to the label (salah rows only). */
+  timeBadge?: string | null;
 }) {
   const { habit } = props;
   const [showHistory, setShowHistory] = useState(false);
@@ -705,6 +715,11 @@ function HabitTrackerRow(props: {
           >
             {habit.label}
           </button>
+          {props.timeBadge && (
+            <span className={styles.prayerTimeBadge} title="Prayer time for the selected day">
+              {props.timeBadge}
+            </span>
+          )}
           {props.streak >= 2 && (
             <span className={styles.streakChip} title={`${props.streak}-day streak`}>
               ×{props.streak}
@@ -925,9 +940,17 @@ export function HabitsBody(props: HabitsBodyProps) {
                 onMark={props.onMark}
                 streak={props.streaks[habit.id] ?? 0}
                 historyFor={props.historyFor}
+                timeBadge={
+                  habit.salah && PRAYER_ID_SET.has(habit.id)
+                    ? (props.prayerTimes?.[habit.id as PrayerKey] ?? null)
+                    : null
+                }
               />
             ))}
           </div>
+          {!props.prayerActive && props.habits.some((h) => h.salah) && (
+            <p className={styles.prayerHint}>Add your city in Customize to see prayer times.</p>
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/features/daily-plan/daily-plan-prayer.test.tsx
+++ b/apps/web/src/features/daily-plan/daily-plan-prayer.test.tsx
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { defaultDailyPlanSettings } from '@lifeline/shared';
+import { ThemeProvider } from '../../app/providers/theme-provider';
+import { renderWithProviders } from '../../test/harness';
+import { DailyPlanView } from './DailyPlanView';
+
+/**
+ * Prayer times on the five salah rows: with a city set, usePrayerTimes fetches
+ * a month from Aladhan (mocked here), caches it, and each prayer habit shows an
+ * HH:MM badge for the selected day. With no city, a quiet hint replaces them.
+ */
+
+/** A one-day calendarByCity payload covering the render date (2026-07-09). */
+const CANNED_MONTH = {
+  code: 200,
+  data: [
+    {
+      timings: {
+        Fajr: '03:12 (EEST)',
+        Sunrise: '05:00 (EEST)',
+        Dhuhr: '12:59 (EEST)',
+        Asr: '16:38 (EEST)',
+        Maghrib: '19:47 (EEST)',
+        Isha: '21:26 (EEST)',
+      },
+      date: { gregorian: { date: '09-07-2026' } },
+    },
+  ],
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function seedPrayerCity(city: string, country = 'Egypt') {
+  const settings = defaultDailyPlanSettings();
+  settings.prayer = { enabled: true, city, country, method: -1 };
+  window.localStorage.setItem('daily_plan_settings', JSON.stringify(settings));
+}
+
+function renderPlan(dayToken = '2026-07-09') {
+  return renderWithProviders(
+    <ThemeProvider>
+      <DailyPlanView dayToken={dayToken} todos={[]} />
+    </ThemeProvider>,
+  );
+}
+
+describe('prayer times on the habit rows', () => {
+  it('shows an HH:MM badge on each salah row and caches the month', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(CANNED_MONTH) } as Response),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    seedPrayerCity('Cairo');
+
+    renderPlan();
+
+    // Fajr and Isha badges (the day's real times, tz suffix stripped).
+    expect(await screen.findByText('03:12')).toBeInTheDocument();
+    expect(await screen.findByText('21:26')).toBeInTheDocument();
+    expect(screen.getByText('12:59')).toBeInTheDocument();
+    expect(screen.getByText('16:38')).toBeInTheDocument();
+    expect(screen.getByText('19:47')).toBeInTheDocument();
+
+    // The Aladhan call went out with the city (Auto omits method).
+    const url = String(fetchMock.mock.calls[0]?.[0] ?? '');
+    expect(url).toContain('calendarByCity/2026/7');
+    expect(url).toContain('city=Cairo');
+    expect(url).not.toContain('method=');
+
+    // The parsed month is mirrored to localStorage for instant/offline reads.
+    await waitFor(() => {
+      const key = Object.keys(localStorage).find((k) => k.startsWith('prayer_times:cairo:'));
+      expect(key).toBeTruthy();
+    });
+  });
+
+  it('shows the add-your-city hint when no city is set (no fetch)', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(CANNED_MONTH) } as Response),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    // Default settings carry an empty prayer city.
+
+    renderPlan();
+
+    expect(
+      await screen.findByText('Add your city in Customize to see prayer times.'),
+    ).toBeInTheDocument();
+    // No city → the query is disabled, so we never hit the network.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/daily-plan/daily-plan-prayer.test.tsx
+++ b/apps/web/src/features/daily-plan/daily-plan-prayer.test.tsx
@@ -53,7 +53,7 @@ function renderPlan(dayToken = '2026-07-09') {
 
 describe('prayer times on the habit rows', () => {
   it('shows an HH:MM badge on each salah row and caches the month', async () => {
-    const fetchMock = vi.fn(() =>
+    const fetchMock = vi.fn((_url: string) =>
       Promise.resolve({ ok: true, json: () => Promise.resolve(CANNED_MONTH) } as Response),
     );
     vi.stubGlobal('fetch', fetchMock);
@@ -82,7 +82,7 @@ describe('prayer times on the habit rows', () => {
   });
 
   it('shows the add-your-city hint when no city is set (no fetch)', async () => {
-    const fetchMock = vi.fn(() =>
+    const fetchMock = vi.fn((_url: string) =>
       Promise.resolve({ ok: true, json: () => Promise.resolve(CANNED_MONTH) } as Response),
     );
     vi.stubGlobal('fetch', fetchMock);

--- a/apps/web/src/features/daily-plan/data/prayer-hooks.ts
+++ b/apps/web/src/features/daily-plan/data/prayer-hooks.ts
@@ -1,0 +1,136 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  buildCalendarUrl,
+  monthKeyOf,
+  parseMonth,
+  timesForDay,
+  type DayPrayers,
+  type PrayerMonth,
+} from '../lib/prayer-times';
+
+/**
+ * usePrayerTimes — the five salah times for a given day, by city.
+ *
+ * We fetch a whole month from Aladhan at once (a month of times is stable),
+ * key the query by month so "today" is a local lookup, and mirror the parsed
+ * month to localStorage so badges render instantly and survive going offline.
+ *
+ * The network call is isolated in `fetchPrayerMonth` on purpose: it is the one
+ * seam that talks to a third party. If the browser-direct call is ever blocked
+ * (CORS / CSP), only this function swaps to a same-origin server proxy — the
+ * hook, cache, and callers stay unchanged.
+ */
+
+const CACHE_PREFIX = 'prayer_times';
+
+/** localStorage key for one city+method+month of parsed times. */
+function cacheKey(city: string, country: string, method: number, monthKey: string): string {
+  return `${CACHE_PREFIX}:${city.trim().toLowerCase()}:${country.trim().toLowerCase()}:${method}:${monthKey}`;
+}
+
+function readCache(key: string): PrayerMonth | null {
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    // Shallow shape guard — a corrupt/foreign blob just misses the cache.
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return parsed as PrayerMonth;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(key: string, month: PrayerMonth): void {
+  try {
+    window.localStorage.setItem(key, JSON.stringify(month));
+  } catch {
+    // Quota/serialization failures are non-fatal — the month stays in the
+    // in-memory query cache for this session.
+  }
+}
+
+/**
+ * Fetch + parse one month of prayer times from Aladhan (browser-direct). The
+ * ONLY function that reaches the network — swap its body for a same-origin
+ * proxy fetch if the direct call is ever blocked.
+ */
+export async function fetchPrayerMonth(
+  city: string,
+  country: string,
+  method: number,
+  year: number,
+  month: number,
+): Promise<PrayerMonth> {
+  const url = buildCalendarUrl(city, country, method, year, month);
+  const response = await fetch(url, { headers: { Accept: 'application/json' } });
+  if (!response.ok) throw new Error(`Aladhan responded ${response.status}`);
+  const json: unknown = await response.json();
+  return parseMonth(json);
+}
+
+export interface PrayerTimesResult {
+  /** The five HH:MM times for `dateStr`, or null (no city, still loading, or that day absent). */
+  times: DayPrayers | null;
+  /** Whether the feature is active (a city is set) — drives the empty-city hint. */
+  active: boolean;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+/**
+ * The five prayer times for `dateStr` (`YYYY-MM-DD`) in `city`. `method` -1 is
+ * Auto. Returns `{ times: null }` until a city is set or the month resolves.
+ */
+export function usePrayerTimes(
+  city: string,
+  country: string,
+  method: number,
+  dateStr: string,
+): PrayerTimesResult {
+  const trimmedCity = city.trim();
+  const active = trimmedCity.length > 0;
+  const monthKey = monthKeyOf(dateStr);
+  const year = Number(dateStr.slice(0, 4));
+  const month = Number(dateStr.slice(5, 7));
+  const key = cacheKey(city, country, method, monthKey);
+
+  const query = useQuery({
+    queryKey: [
+      'prayer-times',
+      trimmedCity.toLowerCase(),
+      country.trim().toLowerCase(),
+      method,
+      monthKey,
+    ],
+    enabled: active && Number.isFinite(year) && Number.isFinite(month),
+    // A month of prayer times doesn't change — refetch rarely, keep long.
+    // gcTime stays under the 32-bit setTimeout ceiling (~24.8 days); the
+    // localStorage mirror below is the real cross-session/offline cache.
+    staleTime: 12 * 60 * 60_000,
+    gcTime: 24 * 60 * 60_000,
+    // Cross-third-party call: one retry is plenty; the cache covers offline.
+    retry: 1,
+    // Show cached badges immediately (and offline) before the network resolves.
+    initialData: () => readCache(key) ?? undefined,
+    queryFn: async () => {
+      try {
+        const fetched = await fetchPrayerMonth(trimmedCity, country, method, year, month);
+        writeCache(key, fetched);
+        return fetched;
+      } catch (err) {
+        // Offline / API down: fall back to any cached month rather than blank.
+        const cached = readCache(key);
+        if (cached) return cached;
+        throw err;
+      }
+    },
+  });
+
+  return {
+    times: query.data ? timesForDay(query.data, dateStr) : null,
+    active,
+    isLoading: query.isLoading,
+    isError: query.isError,
+  };
+}

--- a/apps/web/src/features/daily-plan/lib/prayer-times.test.ts
+++ b/apps/web/src/features/daily-plan/lib/prayer-times.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCalendarUrl,
+  gregorianToIso,
+  monthKeyOf,
+  parseMonth,
+  timeOnly,
+  timesForDay,
+} from './prayer-times';
+
+/**
+ * Prayer-times parsing is pure and defensive: the Aladhan API returns a whole
+ * month of days, each timing string may carry a timezone suffix, and the odd
+ * entry can be malformed. These tests pin URL assembly (incl. Auto) and the
+ * tolerant parse against a canned month response.
+ */
+
+describe('buildCalendarUrl', () => {
+  it('assembles calendarByCity with city + country', () => {
+    const url = buildCalendarUrl('Cairo', 'Egypt', -1, 2026, 7);
+    expect(url).toContain('/calendarByCity/2026/7?');
+    expect(url).toContain('city=Cairo');
+    expect(url).toContain('country=Egypt');
+  });
+
+  it('omits method for Auto (-1) and includes it for an explicit method', () => {
+    expect(buildCalendarUrl('Cairo', 'Egypt', -1, 2026, 7)).not.toContain('method=');
+    expect(buildCalendarUrl('Cairo', 'Egypt', 5, 2026, 7)).toContain('method=5');
+    // 0 is a real Aladhan method (Shia Ithna-Ashari), not "Auto".
+    expect(buildCalendarUrl('Karbala', 'Iraq', 0, 2026, 7)).toContain('method=0');
+  });
+
+  it('url-encodes and trims multi-word city/country', () => {
+    const url = buildCalendarUrl('  New York ', ' United States ', -1, 2026, 7);
+    expect(url).toContain('city=New+York');
+    expect(url).toContain('country=United+States');
+  });
+});
+
+describe('timeOnly', () => {
+  it('strips a timezone suffix down to HH:MM', () => {
+    expect(timeOnly('05:12 (EEST)')).toBe('05:12');
+    expect(timeOnly('19:47 (+03)')).toBe('19:47');
+  });
+
+  it('zero-pads a single-digit hour', () => {
+    expect(timeOnly('5:12')).toBe('05:12');
+  });
+
+  it('rejects out-of-range and non-string input', () => {
+    expect(timeOnly('25:00')).toBeNull();
+    expect(timeOnly('12:75')).toBeNull();
+    expect(timeOnly('not a time')).toBeNull();
+    expect(timeOnly(undefined)).toBeNull();
+    expect(timeOnly(1234)).toBeNull();
+  });
+});
+
+describe('gregorianToIso', () => {
+  it('converts DD-MM-YYYY to YYYY-MM-DD', () => {
+    expect(gregorianToIso('09-07-2026')).toBe('2026-07-09');
+    expect(gregorianToIso('31-12-2026')).toBe('2026-12-31');
+  });
+
+  it('returns null for unparseable shapes', () => {
+    expect(gregorianToIso('2026-07-09')).toBeNull();
+    expect(gregorianToIso('9-7-2026')).toBeNull();
+    expect(gregorianToIso(undefined)).toBeNull();
+    expect(gregorianToIso(42)).toBeNull();
+  });
+});
+
+/** A trimmed, realistic calendarByCity payload: one good day (tz suffix), one
+ * malformed day (missing Isha) that must be skipped, one entry with no date. */
+const cannedMonth = {
+  code: 200,
+  data: [
+    {
+      timings: {
+        Fajr: '03:12 (EEST)',
+        Sunrise: '05:00 (EEST)',
+        Dhuhr: '12:59 (EEST)',
+        Asr: '16:38 (EEST)',
+        Maghrib: '19:47 (EEST)',
+        Isha: '21:26 (EEST)',
+      },
+      date: { gregorian: { date: '09-07-2026' } },
+    },
+    {
+      timings: {
+        Fajr: '03:13 (EEST)',
+        Dhuhr: '12:59 (EEST)',
+        Asr: '16:38 (EEST)',
+        Maghrib: '19:47 (EEST)',
+        // Isha missing → whole day skipped as incomplete.
+      },
+      date: { gregorian: { date: '10-07-2026' } },
+    },
+    {
+      timings: { Fajr: '03:14', Dhuhr: '12:59', Asr: '16:38', Maghrib: '19:47', Isha: '21:25' },
+      // No date → skipped.
+    },
+  ],
+};
+
+describe('parseMonth', () => {
+  it('maps complete days and skips malformed/dateless entries', () => {
+    const month = parseMonth(cannedMonth);
+    expect(Object.keys(month)).toEqual(['2026-07-09']);
+    expect(month['2026-07-09']).toEqual({
+      fajr: '03:12',
+      dhuhr: '12:59',
+      asr: '16:38',
+      maghrib: '19:47',
+      isha: '21:26',
+    });
+  });
+
+  it('never throws on bad shapes, returning an empty month', () => {
+    expect(parseMonth(null)).toEqual({});
+    expect(parseMonth({})).toEqual({});
+    expect(parseMonth({ data: 'nope' })).toEqual({});
+    expect(parseMonth({ data: [null, 42, { date: {} }] })).toEqual({});
+  });
+});
+
+describe('timesForDay / monthKeyOf', () => {
+  it('returns the day when present, null otherwise', () => {
+    const month = parseMonth(cannedMonth);
+    expect(timesForDay(month, '2026-07-09')?.fajr).toBe('03:12');
+    expect(timesForDay(month, '2026-07-10')).toBeNull();
+  });
+
+  it('derives the YYYY-MM month key from a date string', () => {
+    expect(monthKeyOf('2026-07-09')).toBe('2026-07');
+    expect(monthKeyOf('2026-12-31')).toBe('2026-12');
+  });
+});

--- a/apps/web/src/features/daily-plan/lib/prayer-times.ts
+++ b/apps/web/src/features/daily-plan/lib/prayer-times.ts
@@ -1,0 +1,108 @@
+/**
+ * Prayer times for the Daily Plan's five salah habits, from the free Aladhan
+ * API (no key). We fetch a whole month at once (calendarByCity) so "today" is
+ * a local lookup and the result caches cleanly — a month of times is stable.
+ *
+ * All parsing here is pure and defensive: the API's time strings can carry a
+ * timezone suffix ("05:12 (EEST)") and the odd entry may be malformed, so we
+ * extract just HH:MM and skip anything we can't read rather than throw.
+ *
+ * The five prayer HABITS are identified by fixed ids (fajr/dhuhr/asr/maghrib/
+ * isha); PRAYER_HABIT_IDS maps a habit id to its timing so the habit row can
+ * show the time. Custom salah habits without a matching id simply get none.
+ */
+
+export const PRAYER_HABIT_IDS = ['fajr', 'dhuhr', 'asr', 'maghrib', 'isha'] as const;
+export type PrayerKey = (typeof PRAYER_HABIT_IDS)[number];
+
+/** habit id → the Aladhan timing key. */
+const TIMING_KEY: Record<PrayerKey, string> = {
+  fajr: 'Fajr',
+  dhuhr: 'Dhuhr',
+  asr: 'Asr',
+  maghrib: 'Maghrib',
+  isha: 'Isha',
+};
+
+export type DayPrayers = Record<PrayerKey, string>;
+/** 'YYYY-MM-DD' → the five HH:MM times for that day. */
+export type PrayerMonth = Record<string, DayPrayers>;
+
+const ALADHAN_BASE = 'https://api.aladhan.com/v1';
+
+/**
+ * calendarByCity for one month. method -1 = Auto (omit the param so the API
+ * picks the closest authority for the city).
+ */
+export function buildCalendarUrl(
+  city: string,
+  country: string,
+  method: number,
+  year: number,
+  month: number,
+): string {
+  const params = new URLSearchParams({ city: city.trim(), country: country.trim() });
+  if (method >= 0) params.set('method', String(method));
+  return `${ALADHAN_BASE}/calendarByCity/${year}/${month}?${params.toString()}`;
+}
+
+/** First HH:MM in a raw timing string ("05:12 (EEST)" → "05:12"); null if none. */
+export function timeOnly(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  const match = raw.match(/(\d{1,2}):(\d{2})/);
+  if (!match) return null;
+  const h = Number(match[1]);
+  const m = Number(match[2]);
+  if (h > 23 || m > 59) return null;
+  return `${h < 10 ? '0' : ''}${h}:${match[2]}`;
+}
+
+/** Aladhan gregorian "DD-MM-YYYY" → "YYYY-MM-DD"; null if unparseable. */
+export function gregorianToIso(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  const match = raw.match(/^(\d{2})-(\d{2})-(\d{4})$/);
+  return match ? `${match[3]}-${match[2]}-${match[1]}` : null;
+}
+
+interface RawEntry {
+  timings?: Record<string, unknown>;
+  date?: { gregorian?: { date?: unknown } };
+}
+
+/**
+ * Parse a calendarByCity response into a date-keyed month. Entries missing a
+ * date or any of the five prayers are skipped (never throws on bad shapes).
+ */
+export function parseMonth(json: unknown): PrayerMonth {
+  const data = (json as { data?: unknown })?.data;
+  if (!Array.isArray(data)) return {};
+  const out: PrayerMonth = {};
+  for (const entry of data as RawEntry[]) {
+    const iso = gregorianToIso(entry?.date?.gregorian?.date);
+    if (!iso) continue;
+    const timings = entry?.timings;
+    if (!timings || typeof timings !== 'object') continue;
+    const day = {} as DayPrayers;
+    let complete = true;
+    for (const id of PRAYER_HABIT_IDS) {
+      const time = timeOnly(timings[TIMING_KEY[id]]);
+      if (time === null) {
+        complete = false;
+        break;
+      }
+      day[id] = time;
+    }
+    if (complete) out[iso] = day;
+  }
+  return out;
+}
+
+/** The five times for one day, or null if that day isn't in the month. */
+export function timesForDay(month: PrayerMonth, dateStr: string): DayPrayers | null {
+  return month[dateStr] ?? null;
+}
+
+/** 'YYYY-MM' key for the month containing dateStr (cache + query granularity). */
+export function monthKeyOf(dateStr: string): string {
+  return dateStr.slice(0, 7);
+}

--- a/packages/shared/src/daily-plan.test.ts
+++ b/packages/shared/src/daily-plan.test.ts
@@ -80,6 +80,8 @@ describe('dailyPlanSettingsSchema', () => {
     expect(settings.gratitudeCount).toBe(3);
     expect(settings.tomorrowCount).toBe(4);
     expect(settings.templates).toEqual({});
+    // Prayer times default dormant (no city) with Auto calculation method.
+    expect(settings.prayer).toEqual({ enabled: true, city: '', country: '', method: -1 });
   });
 
   it('day templates roundtrip per weekday and stored pre-personalization blobs self-heal', () => {

--- a/packages/shared/src/daily-plan.ts
+++ b/packages/shared/src/daily-plan.ts
@@ -403,6 +403,20 @@ export const dailyPlanSettingsSchema = z.object({
   /** Height in cm (canonical); 0 = unset. Near-static, so it lives in settings. */
   height: z.number().min(0).max(300).default(0),
   /**
+   * Prayer times: the five salah habits show accurate times fetched by city.
+   * method -1 = Auto (let the provider pick the closest authority for the
+   * location); 0–23 / 99 are explicit calculation methods. Empty city = the
+   * feature is dormant. Seeded once from the user's profile city on first load.
+   */
+  prayer: z
+    .object({
+      enabled: z.boolean().default(true),
+      city: z.string().max(120).default(''),
+      country: z.string().max(120).default(''),
+      method: z.number().int().min(-1).max(99).default(-1),
+    })
+    .default({ enabled: true, city: '', country: '', method: -1 }),
+  /**
    * Energy profile for BMR/TDEE (see energy.ts). Katch-McArdle needs only
    * weight + fat%; Mifflin-St Jeor needs all four. 'unset'/0 = not provided —
    * the engine returns null rather than guessing.


### PR DESCRIPTION
## Summary

The five daily prayers already live in the Daily Plan as habits (`fajr`…`isha`), but they carried **no time** — and prayer times depend on where you are. This adds a **city** field (at onboarding and in Customize) and shows each prayer's accurate time on its habit row.

- **Where the time comes from:** the free **Aladhan API** (`calendarByCity`, no key). We fetch a **whole month at once**, so "today" is a local lookup and the result **caches to `localStorage`** — badges render instantly and survive going **offline**. Default calculation method is **Auto** (the API picks the closest authority for the city); an **Advanced** picker overrides it (MWL / ISNA / Umm al-Qura / Egyptian / Karachi / …).
- **Shared schema:** new `prayer` object on `DailyPlanSettings` (`enabled` / `city` / `country` / `method`; `-1` = Auto). Optional-with-default, so old blobs self-heal.
- **`lib/prayer-times.ts`** (pure, 12 unit tests): tolerant parse — strips a `(EEST)`-style tz suffix down to `HH:MM`, maps `DD-MM-YYYY`→ISO, skips malformed days without throwing — plus URL assembly that **omits `method` for Auto**.
- **`data/prayer-hooks.ts`** — `usePrayerTimes`: month-keyed React Query, long `staleTime`, a `localStorage` mirror, and a **single isolated `fetch` seam** (`fetchPrayerMonth`) so transport can swap to a server proxy without touching callers; falls back to cache when the network is down.
- **Display:** a quiet `HH:MM` badge on each of the five salah rows (selected day), tabular-nums + `--plan-scale`-aware; a gentle "Add your city in Customize" hint when no city is set. The plan **auto-seeds** the prayer city from the account profile once, so an onboarding-only user gets times without re-entering.
- **Customize:** a **Prayer times** section (city / country, show-times toggle, Advanced method select).
- **Onboarding:** a **City** field → profile `PUT` (`city` was already accepted server-side).
- **CSP:** allow `https://api.aladhan.com` in `connect-src` (browser-direct fetch), with a regression test pinning it.

**Verified in-browser** (402×874, guest, paper theme): with a city set, the five salah rows show today's times (`الفجر 03:15`, `الظهر 13:00`, `العصر 16:39`, `المغرب 19:45`, `العشاء 21:23`) from the seeded month cache; with no city, the salah rows show the "add your city" hint and **no network call** goes out; the Customize **Prayer times** section renders with the city/country inputs, the toggle, and the Advanced method picker (Auto — best for your city). Full suites green — shared 42, web 271 (incl. new prayer + onboarding tests), server 368 (incl. new CSP assertion); lint, prettier, and `tsc` (web + server) clean.

> ⚠️ **One thing that can only be confirmed on a real device:** Aladhan's outbound host is blocked from the build sandbox, so the **live CORS/CSP round-trip to `api.aladhan.com` couldn't be exercised here** — the display, cache, and offline paths were verified against a mocked/seeded month. If the browser-direct call turns out to be blocked in production, the fix is contained to the one `fetchPrayerMonth` seam (swap it for a same-origin server proxy; no CSP change and no other code changes). Please sanity-check on your phone once deployed.

## Change Type
- [x] Product behavior
- [x] Feature scope
- [x] Frontend behavior
- [x] Backend behavior
- [ ] API contract
- [x] Data model
- [ ] Architecture
- [ ] Operations / deployment

## Documentation Impact
- [x] I evaluated documentation impact.
- [ ] I updated the relevant docs.
- [x] No docs update was needed, and I explained why below.

## Docs Updated

None.

## If no docs were updated, explain why

The only contract change is an additive settings field (`prayer`) with a schema default — old blobs parse unchanged — plus one CSP `connect-src` allowlist entry. No public API, endpoint, or documented interface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV)_