### PR TITLE
feat(plan): link tasks to habits — completing the task checks the habit

### DIFF
--- a/apps/server/src/application/ports.ts
+++ b/apps/server/src/application/ports.ts
@@ -153,6 +153,8 @@ export interface NewTodoData {
   subtasks: SubtaskRecord[];
   order: number;
   recurrence: Recurrence | null;
+  /** Daily Plan habit this task counts toward (copied to every expanded row). */
+  habitId: string | null;
   originalId: string | null;
   /** Resolved tag ids (unknown ids must be dropped before this point). */
   tagIds: string[];
@@ -168,6 +170,7 @@ export interface TodoUpdateData {
   priority?: Priority | undefined;
   subtasks?: SubtaskRecord[] | undefined;
   order?: number | undefined;
+  habitId?: string | null | undefined;
   tagIds?: string[] | undefined;
 }
 

--- a/apps/server/src/application/todos/create-todo.test.ts
+++ b/apps/server/src/application/todos/create-todo.test.ts
@@ -180,6 +180,18 @@ describe('CreateTodo — subtask normalization (stable identity)', () => {
     expect(ids.size).toBe(1);
   });
 
+  it('the habit link is copied onto every expanded recurrence row', async () => {
+    const { todos, createTodo } = build();
+    await createTodo.execute('u1', 'free', {
+      title: 'Daily Udemy hour',
+      habitId: 'udemy',
+      recurrence: { mode: 'daily', startDate: '2026-03-01', endDate: '2026-03-03' },
+    });
+    const rows = todos.rowsFor('u1');
+    expect(rows).toHaveLength(3);
+    expect(rows.every((row) => row.habitId === 'udemy')).toBe(true);
+  });
+
   it('resolves tag references and drops unknown ids', async () => {
     const { createTodo } = build();
     const { todo } = await createTodo.execute('u1', 'free', {

--- a/apps/server/src/application/todos/create-todo.ts
+++ b/apps/server/src/application/todos/create-todo.ts
@@ -58,6 +58,9 @@ export class CreateTodo {
       subtasks,
       order: 0,
       recurrence,
+      // The habit link rides on every expanded occurrence — a recurring task
+      // drives its habit each day it recurs.
+      habitId: input.habitId ?? null,
       originalId: null,
       tagIds,
     }));

--- a/apps/server/src/application/todos/update-todo.ts
+++ b/apps/server/src/application/todos/update-todo.ts
@@ -44,6 +44,7 @@ export class UpdateTodo {
     if (input.priority !== undefined) changes.priority = input.priority;
     if (input.subtasks !== undefined) changes.subtasks = normalizeSubtasks(input.subtasks);
     if (input.order !== undefined) changes.order = input.order;
+    if (input.habitId !== undefined) changes.habitId = input.habitId ?? null;
     if (input.tags !== undefined) {
       changes.tagIds = await resolveTagReferenceIds(this.deps.tags, userId, input.tags);
     }

--- a/apps/server/src/infrastructure/db/migrations/0002_todo_habit_id.sql
+++ b/apps/server/src/infrastructure/db/migrations/0002_todo_habit_id.sql
@@ -1,0 +1,8 @@
+-- 0002_todo_habit_id — task ↔ habit link (hand-authored, additive only).
+--
+-- Nullable Daily Plan habit id on todos: completing a task checks its linked
+-- habit for the task's due date (recomputed client-side; the column is plain
+-- storage). IF NOT EXISTS keeps the file idempotent, matching convention;
+-- existing rows read as NULL (no link).
+
+ALTER TABLE "todos" ADD COLUMN IF NOT EXISTS "habit_id" text;

--- a/apps/server/src/infrastructure/db/migrations/meta/_journal.json
+++ b/apps/server/src/infrastructure/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1783728000000,
       "tag": "0001_daily_plans",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1784246400000,
+      "tag": "0002_todo_habit_id",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/infrastructure/db/schema.ts
+++ b/apps/server/src/infrastructure/db/schema.ts
@@ -132,6 +132,8 @@ export const todos = pgTable(
     /** Reserved word — quoted column name "order". */
     order: integer('order').notNull().default(0),
     recurrence: jsonb('recurrence').$type<Recurrence>(),
+    /** Daily Plan habit this task counts toward (completing it checks the habit). */
+    habitId: text('habit_id'),
     /** Dead field in practice (always null); kept for data compatibility. */
     nextRecurrenceDue: timestamp('next_recurrence_due', { withTimezone: true }),
     originalId: text('original_id'),

--- a/apps/server/src/infrastructure/repositories/todo-repository.ts
+++ b/apps/server/src/infrastructure/repositories/todo-repository.ts
@@ -71,6 +71,7 @@ function toTodoDto(row: TodoRow, tagList: Tag[]): Todo {
     subtasks: row.subtasks,
     order: row.order,
     recurrence: row.recurrence ?? null,
+    habitId: row.habitId,
     originalId: row.originalId,
     archived: row.archived,
     createdAt: row.createdAt.toISOString(),
@@ -151,6 +152,7 @@ async function insertTodoRow(tx: Tx, userId: string, data: NewTodoData): Promise
       subtasks: data.subtasks,
       order: data.order,
       recurrence: data.recurrence,
+      habitId: data.habitId,
       originalId: data.originalId,
     })
     .returning();
@@ -471,6 +473,7 @@ export class DrizzleTodoRepository implements TodoRepository, ImportTodoWriter {
       if (changes.priority !== undefined) set.priority = changes.priority;
       if (changes.subtasks !== undefined) set.subtasks = changes.subtasks;
       if (changes.order !== undefined) set.order = changes.order;
+      if (changes.habitId !== undefined) set.habitId = changes.habitId;
 
       const rows = await tx
         .update(todos)

--- a/apps/server/src/mcp/helpers.test.ts
+++ b/apps/server/src/mcp/helpers.test.ts
@@ -42,6 +42,7 @@ function makeTodo(partial: Partial<Todo> = {}): Todo {
     subtasks: [],
     order: 0,
     recurrence: null,
+    habitId: null,
     originalId: null,
     archived: false,
     createdAt: '2026-07-01T00:00:00.000Z',

--- a/apps/server/test/helpers/feature-fakes.ts
+++ b/apps/server/test/helpers/feature-fakes.ts
@@ -165,6 +165,7 @@ export class InMemoryTodoRepository implements TodoRepository, ImportTodoWriter 
       subtasks: [],
       order: 0,
       recurrence: null,
+      habitId: null,
       originalId: null,
       archived: false,
       createdAt: now,
@@ -322,6 +323,7 @@ export class InMemoryTodoRepository implements TodoRepository, ImportTodoWriter 
     if (changes.priority !== undefined) todo.priority = changes.priority;
     if (changes.subtasks !== undefined) todo.subtasks = changes.subtasks;
     if (changes.order !== undefined) todo.order = changes.order;
+    if (changes.habitId !== undefined) todo.habitId = changes.habitId;
     if (changes.tagIds !== undefined) todo.tags = this.resolveTags(userId, changes.tagIds);
     todo.updatedAt = new Date().toISOString();
     this.store.set(id, { userId, todo });
@@ -377,6 +379,7 @@ export class InMemoryTodoRepository implements TodoRepository, ImportTodoWriter 
           subtasks: [],
           order: 0,
           recurrence: null,
+          habitId: null,
           originalId: null,
           archived: false,
           createdAt: now,
@@ -492,6 +495,7 @@ export class InMemoryTodoRepository implements TodoRepository, ImportTodoWriter 
       subtasks: data.subtasks,
       order: data.order,
       recurrence: data.recurrence,
+      habitId: data.habitId,
       originalId: data.originalId,
       archived: false,
       createdAt: now,

--- a/apps/server/test/integration/todos.integration.test.ts
+++ b/apps/server/test/integration/todos.integration.test.ts
@@ -30,6 +30,7 @@ function newTodo(overrides: Partial<NewTodoData> = {}): NewTodoData {
     subtasks: [],
     order: 0,
     recurrence: null,
+    habitId: null,
     originalId: null,
     tagIds: [],
     ...overrides,

--- a/apps/server/test/routers/todos.router.test.ts
+++ b/apps/server/test/routers/todos.router.test.ts
@@ -103,6 +103,23 @@ describe('POST /api/v1/todos', () => {
     expect(response.headers['x-total-created']).toBe('1');
   });
 
+  it('habitId roundtrips: set at create, changed and cleared via PATCH', async () => {
+    const created = await request(app)
+      .post('/api/v1/todos')
+      .send({ title: 'Udemy hour', habitId: 'udemy' });
+    expect(created.status).toBe(201);
+    expect(created.body.habitId).toBe('udemy');
+
+    const id = created.body.id as string;
+    const relinked = await request(app).patch(`/api/v1/todos/${id}`).send({ habitId: 'reading' });
+    expect(relinked.status).toBe(200);
+    expect(relinked.body.habitId).toBe('reading');
+
+    const cleared = await request(app).patch(`/api/v1/todos/${id}`).send({ habitId: null });
+    expect(cleared.status).toBe(200);
+    expect(cleared.body.habitId).toBeNull();
+  });
+
   it('400 problem with field errors for an empty body', async () => {
     const response = await request(app).post('/api/v1/todos').send({});
     expectProblem(response, 400, 'validation_failed');

--- a/apps/web/src/app/pages/DashboardPage.tsx
+++ b/apps/web/src/app/pages/DashboardPage.tsx
@@ -26,6 +26,7 @@ import {
 import type { SortOption } from '../../features/todos/lib/day-filter';
 import { formatDuration } from '../../features/todos/lib/format';
 import { DailyPlanView } from '../../features/daily-plan/DailyPlanView';
+import { usePlanSettings } from '../../features/daily-plan/data/hooks';
 import { useHomeViewMode } from '../../features/daily-plan/data/view-mode';
 import { ApiError } from '../../shared/api/client';
 import { SparklesIcon } from '../../shared/ui/icons';
@@ -63,6 +64,8 @@ export default function DashboardPage() {
 
   const todosQuery = useAllTodos();
   const tagsQuery = useAllTags();
+  // Plan habits feed the composer's "Counts toward habit" select in Tasks mode.
+  const { settings: planSettings } = usePlanSettings();
   useRefreshOnDayChange(day);
 
   const [selectedFilterTags, setSelectedFilterTags] = useState<string[]>([]);
@@ -415,6 +418,7 @@ export default function DashboardPage() {
             allTodos={todosQuery.data ?? []}
             effectiveDate={day}
             onRequestClose={() => setComposerOpen(false)}
+            habits={planSettings.habits}
           />
 
           {/* ── task list ────────────────────────────────────────────────── */}

--- a/apps/web/src/features/daily-plan/ComposerModal.tsx
+++ b/apps/web/src/features/daily-plan/ComposerModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import type { Tag, Todo } from '@lifeline/shared';
+import type { PlanHabit, Tag, Todo } from '@lifeline/shared';
 import { Composer } from '../todos/components/Composer';
 import styles from './ComposerModal.module.css';
 
@@ -14,6 +14,8 @@ export interface ComposerModalProps {
   initialDueDate?: string | undefined;
   /** Preset due time ('HH:mm') re-applied on every open. */
   initialDueTime?: string | undefined;
+  /** Plan habits for the "Counts toward habit" select. */
+  habits?: readonly PlanHabit[] | undefined;
   onClose: () => void;
 }
 
@@ -32,6 +34,7 @@ export function ComposerModal({
   effectiveDate,
   initialDueDate,
   initialDueTime,
+  habits,
   onClose,
 }: ComposerModalProps) {
   // Lock the page behind the popup — on phones the background otherwise
@@ -84,6 +87,7 @@ export function ComposerModal({
           initialDueTime={initialDueTime}
           closeOnOutsideClick={false}
           initialFocus="title"
+          habits={habits}
         />
       </div>
     </div>,

--- a/apps/web/src/features/daily-plan/DailyPlanView.tsx
+++ b/apps/web/src/features/daily-plan/DailyPlanView.tsx
@@ -1186,6 +1186,7 @@ export function DailyPlanView({
         effectiveDate={composerTarget.date}
         initialDueDate={composerTarget.date}
         initialDueTime={composerTarget.time}
+        habits={settings.habits}
         onClose={closeComposer}
       />
 
@@ -1199,6 +1200,8 @@ export function DailyPlanView({
           openTask(todo, todo.dueDate ?? dateStr);
         }}
         onMove={moveTask}
+        habits={settings.habits}
+        onLinkHabit={(todo, habitId) => updateTodo.mutate({ id: todo.id, patch: { habitId } })}
       />
 
       {toast && (

--- a/apps/web/src/features/daily-plan/TaskPreviewModal.module.css
+++ b/apps/web/src/features/daily-plan/TaskPreviewModal.module.css
@@ -360,3 +360,23 @@
   border-color: var(--color-primary);
   background: var(--color-surface-light);
 }
+
+/* "Counts toward habit" select — pill styling matching the move controls. */
+.habitSelect {
+  flex: 1;
+  min-width: 0;
+  padding: var(--space-6) var(--space-10);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-surface);
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.habitSelect:hover,
+.habitSelect:focus-visible {
+  border-color: var(--color-primary);
+}

--- a/apps/web/src/features/daily-plan/TaskPreviewModal.tsx
+++ b/apps/web/src/features/daily-plan/TaskPreviewModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { addDays, format, parseISO } from 'date-fns';
-import type { Todo } from '@lifeline/shared';
+import type { PlanHabit, Todo } from '@lifeline/shared';
 import { SquareCheck } from './cards';
 import styles from './TaskPreviewModal.module.css';
 
@@ -47,6 +47,10 @@ export interface TaskPreviewModalProps {
   onEdit: (todo: Todo) => void;
   /** Reschedule the task's due date ('YYYY-MM-DD'). */
   onMove?: ((todo: Todo, dateStr: string) => void) | undefined;
+  /** Plan habits for the "Counts toward habit" select (absent hides it). */
+  habits?: readonly PlanHabit[] | undefined;
+  /** Link/unlink the task to a habit (null clears the link). */
+  onLinkHabit?: ((todo: Todo, habitId: string | null) => void) | undefined;
 }
 
 export function TaskPreviewModal({
@@ -56,6 +60,8 @@ export function TaskPreviewModal({
   onToggleSubtask,
   onEdit,
   onMove,
+  habits,
+  onLinkHabit,
 }: TaskPreviewModalProps) {
   const open = todo !== null;
   useEffect(() => {
@@ -173,6 +179,25 @@ export function TaskPreviewModal({
                 </li>
               ))}
             </ul>
+          </div>
+        )}
+
+        {habits && habits.length > 0 && onLinkHabit && (
+          <div className={styles.moveRow}>
+            <span className={styles.moveLabel}>Counts toward</span>
+            <select
+              className={styles.habitSelect}
+              value={todo.habitId ?? ''}
+              aria-label="Counts toward habit"
+              onChange={(event) => onLinkHabit(todo, event.target.value || null)}
+            >
+              <option value="">No habit</option>
+              {habits.map((habit) => (
+                <option key={habit.id} value={habit.id}>
+                  ✓ {habit.label}
+                </option>
+              ))}
+            </select>
           </div>
         )}
 

--- a/apps/web/src/features/daily-plan/daily-plan-habit-sync.test.tsx
+++ b/apps/web/src/features/daily-plan/daily-plan-habit-sync.test.tsx
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Todo } from '@lifeline/shared';
+import { ThemeProvider } from '../../app/providers/theme-provider';
+import { newQueryClient, renderWithProviders } from '../../test/harness';
+import { makeTodo, seedGuestTodos } from '../../test/test-utils';
+import { useUpdateTodo } from '../todos/data/hooks';
+import { todosQueryKey } from '../todos/data/keys';
+import { DailyPlanView } from './DailyPlanView';
+
+/**
+ * Task ↔ habit sync, end to end in guest mode: completing a task linked to a
+ * habit checks that habit for the task's day; the check is EARNED BY RULE
+ * (any-done), so multiple tasks feeding one habit stay coherent; moving a
+ * completed task re-credits the right day.
+ */
+
+const DAY = '2026-07-09';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+function renderPlan(todos: Todo[]) {
+  seedGuestTodos(todos);
+  return renderWithProviders(
+    <ThemeProvider>
+      <DailyPlanView dayToken={DAY} todos={todos} />
+    </ThemeProvider>,
+  );
+}
+
+function storedHabits(date = DAY): Record<string, unknown> {
+  const raw = window.localStorage.getItem(`daily_plan:${date}`);
+  if (!raw) return {};
+  return (JSON.parse(raw) as { habits?: Record<string, unknown> }).habits ?? {};
+}
+
+describe('task → habit sync', () => {
+  it('completing a linked task checks its habit for that day; unchecking clears it', async () => {
+    const task = makeTodo({ title: 'Watch course', habitId: 'udemy', dueDate: DAY });
+    renderPlan([task]);
+    const user = userEvent.setup();
+
+    const check = await screen.findByRole('button', { name: `Toggle task ${task.taskNumber}` });
+    await user.click(check);
+    await waitFor(() => expect(storedHabits()['udemy']).toBe(true));
+
+    // Undo → the ✓ was earned by the task, so it un-earns.
+    await user.click(screen.getByRole('button', { name: `Toggle task ${task.taskNumber}` }));
+    await waitFor(() => expect(storedHabits()['udemy']).toBeUndefined());
+  });
+
+  it('two tasks, one habit: ANY-done semantics, order-independent', async () => {
+    const a = makeTodo({ title: 'Udemy module 1', habitId: 'udemy', dueDate: DAY });
+    const b = makeTodo({ title: 'Udemy module 2', habitId: 'udemy', dueDate: DAY });
+    renderPlan([a, b]);
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByRole('button', { name: `Toggle task ${a.taskNumber}` }));
+    await waitFor(() => expect(storedHabits()['udemy']).toBe(true));
+    await user.click(screen.getByRole('button', { name: `Toggle task ${b.taskNumber}` }));
+    await waitFor(() => expect(storedHabits()['udemy']).toBe(true));
+
+    // Uncheck the FIRST — the second still earns the ✓.
+    await user.click(screen.getByRole('button', { name: `Toggle task ${a.taskNumber}` }));
+    // (give the sync a beat, then assert it stayed)
+    await waitFor(() => expect(storedHabits()['udemy']).toBe(true));
+
+    // Uncheck the last — now nothing earns it.
+    await user.click(screen.getByRole('button', { name: `Toggle task ${b.taskNumber}` }));
+    await waitFor(() => expect(storedHabits()['udemy']).toBeUndefined());
+  });
+
+  it('moving a completed linked task re-credits the new day and clears the old one', async () => {
+    // Completed rows deliberately have no preview in the plan, so the move
+    // goes through the same mutation the Tasks editor uses — a probe button.
+    const task = makeTodo({
+      title: 'Watch course',
+      habitId: 'udemy',
+      dueDate: DAY,
+      isCompleted: true,
+    });
+    const NEXT = '2026-07-10';
+    function MoveProbe({ to }: { to: string }) {
+      const update = useUpdateTodo();
+      return (
+        <button
+          type="button"
+          onClick={() => update.mutate({ id: task.id, patch: { dueDate: to } })}
+        >
+          probe-move-{to}
+        </button>
+      );
+    }
+    seedGuestTodos([task]);
+    // Prime the list cache (in the app, useAllTodos always populates it before
+    // any task UI renders) — the update path reads the pre-move row from it.
+    const queryClient = newQueryClient();
+    queryClient.setQueryData(todosQueryKey(true), [task]);
+    renderWithProviders(
+      <ThemeProvider>
+        <DailyPlanView dayToken={DAY} todos={[task]} />
+        <MoveProbe to={NEXT} />
+        <MoveProbe to={DAY} />
+      </ThemeProvider>,
+      { queryClient },
+    );
+    const user = userEvent.setup();
+
+    // Move the COMPLETED task to tomorrow → tomorrow earns the ✓, today never
+    // had a stored one. Then move it back → tomorrow's ✓ clears, today earns.
+    await user.click(await screen.findByRole('button', { name: `probe-move-${NEXT}` }));
+    await waitFor(() => expect(storedHabits(NEXT)['udemy']).toBe(true));
+    expect(storedHabits(DAY)['udemy']).toBeUndefined();
+
+    await user.click(screen.getByRole('button', { name: `probe-move-${DAY}` }));
+    await waitFor(() => expect(storedHabits(DAY)['udemy']).toBe(true));
+    await waitFor(() => expect(storedHabits(NEXT)['udemy']).toBeUndefined());
+  });
+
+  it('the composer creates the task carrying its habit link', async () => {
+    renderPlan([]);
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByLabelText('Add task at 05:00'));
+    const dialog = await screen.findByRole('dialog', { name: 'Add task' });
+    await user.type(within(dialog).getByLabelText('Task title'), 'Morning course');
+    await user.selectOptions(within(dialog).getByLabelText('Counts toward habit'), 'udemy');
+    await user.click(within(dialog).getByRole('button', { name: 'Add Task' }));
+
+    await waitFor(() => {
+      const raw = window.localStorage.getItem('guest_todos');
+      const todos = JSON.parse(raw as string) as { title: string; habitId: string | null }[];
+      expect(todos[0]).toMatchObject({ title: 'Morning course', habitId: 'udemy' });
+    });
+  });
+
+  it('linking an existing task from the preview popup persists the link', async () => {
+    const task = makeTodo({ title: 'Read a chapter', dueDate: DAY });
+    renderPlan([task]);
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByRole('button', { name: 'Read a chapter' }));
+    const dialog = await screen.findByRole('dialog', { name: /Task/ });
+    await user.selectOptions(within(dialog).getByLabelText('Counts toward habit'), 'reading');
+
+    await waitFor(() => {
+      const raw = window.localStorage.getItem('guest_todos');
+      const todos = JSON.parse(raw as string) as { id: string; habitId: string | null }[];
+      expect(todos.find((t) => t.id === task.id)?.habitId).toBe('reading');
+    });
+  });
+});

--- a/apps/web/src/features/daily-plan/data/habit-task-sync.test.ts
+++ b/apps/web/src/features/daily-plan/data/habit-task-sync.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { makeTodo } from '../../../test/test-utils';
+import { habitSyncTargets, recomputeHabitMark } from './habit-task-sync';
+
+/**
+ * The recompute rule, pinned: a habit's day-✓ is EARNED if any linked task due
+ * that day is completed. Order-independent, so multiple tasks feeding one
+ * habit can never disagree about the outcome.
+ */
+
+const DATE = '2026-07-09';
+const linked = (over: Parameters<typeof makeTodo>[0] = {}) =>
+  makeTodo({ habitId: 'udemy', dueDate: DATE, ...over });
+
+describe('recomputeHabitMark', () => {
+  it('any completed linked task earns the ✓ (second task is a no-op)', () => {
+    const one = [linked({ isCompleted: true }), linked({ isCompleted: false })];
+    expect(recomputeHabitMark(undefined, one, 'udemy', DATE)).toBe(true);
+    // Both done → still just ✓.
+    const both = [linked({ isCompleted: true }), linked({ isCompleted: true })];
+    expect(recomputeHabitMark(true, both, 'udemy', DATE)).toBe(true);
+  });
+
+  it('unchecking one of two keeps the ✓; unchecking the last clears it', () => {
+    const oneLeft = [linked({ isCompleted: false }), linked({ isCompleted: true })];
+    expect(recomputeHabitMark(true, oneLeft, 'udemy', DATE)).toBe(true);
+    const noneLeft = [linked({ isCompleted: false }), linked({ isCompleted: false })];
+    expect(recomputeHabitMark(true, noneLeft, 'udemy', DATE)).toBeUndefined();
+  });
+
+  it("never clears a manual 'skip' or explicit ✗ — only an earned ✓", () => {
+    const none = [linked({ isCompleted: false })];
+    expect(recomputeHabitMark('skip', none, 'udemy', DATE)).toBe('skip');
+    expect(recomputeHabitMark(false, none, 'udemy', DATE)).toBe(false);
+    expect(recomputeHabitMark(undefined, none, 'udemy', DATE)).toBeUndefined();
+  });
+
+  it('completing overrides a manual skip/✗ (doing the task IS doing the habit)', () => {
+    const done = [linked({ isCompleted: true })];
+    expect(recomputeHabitMark('skip', done, 'udemy', DATE)).toBe(true);
+    expect(recomputeHabitMark(false, done, 'udemy', DATE)).toBe(true);
+  });
+
+  it('ignores other habits, other days, and archived tasks', () => {
+    const noise = [
+      linked({ isCompleted: true, habitId: 'gym' }),
+      linked({ isCompleted: true, dueDate: '2026-07-10' }),
+      linked({ isCompleted: true, archived: true }),
+    ];
+    expect(recomputeHabitMark(true, noise, 'udemy', DATE)).toBeUndefined();
+  });
+});
+
+describe('habitSyncTargets', () => {
+  it('collects (habit, day) pairs from linked+dated todos, deduped', () => {
+    const a = linked();
+    const b = linked(); // same pair as a
+    const moved = linked({ dueDate: '2026-07-10' });
+    const unlinked = makeTodo({ dueDate: DATE });
+    const dateless = makeTodo({ habitId: 'udemy', dueDate: null });
+    expect(habitSyncTargets(a, b, moved, unlinked, dateless, undefined)).toEqual([
+      { habitId: 'udemy', date: DATE },
+      { habitId: 'udemy', date: '2026-07-10' },
+    ]);
+  });
+});

--- a/apps/web/src/features/daily-plan/data/habit-task-sync.ts
+++ b/apps/web/src/features/daily-plan/data/habit-task-sync.ts
@@ -1,0 +1,146 @@
+import { useCallback } from 'react';
+import { useQueryClient, type QueryClient } from '@tanstack/react-query';
+import {
+  dailyPlanSettingsSchema,
+  type DailyPlanData,
+  type DailyPlanDay,
+  type DailyPlanSettings,
+  type HabitMark,
+  type Todo,
+} from '@lifeline/shared';
+import { useAuth } from '../../../app/providers/auth-context';
+import { guestApi } from '../../../shared/guest/guest-api';
+import { todosQueryKey } from '../../todos/data/keys';
+import { materializeNewDay } from '../lib/templates';
+import { weekStartOf } from '../lib/plan-model';
+import { localPlanApi, serverPlanApi, type PlanApi } from './plan-api';
+import { writePlanDayImmediate } from './hooks';
+
+/**
+ * Task → habit sync. A task can be linked to a Daily Plan habit (`habitId`);
+ * the habit's check for a day is then EARNED BY RULE, recomputed on every
+ * linked-task event:
+ *
+ *   ≥1 linked task due that day completed → habit ✓ for that day (doing the
+ *   task IS doing the habit, so this overrides a manual ✗/skip)
+ *   0 completed → only a ✓ is cleared — a manual 'skip'/✗ stands, and days
+ *   with no linked-task activity are never visited
+ *
+ * The rule is order-independent, so several tasks feeding one habit stay
+ * coherent: completing a second task is a no-op, unchecking one of two keeps
+ * the ✓ (the other still earns it), unchecking the last clears it.
+ *
+ * Only tasks WITH a due date participate — the habit grid is per-day, and a
+ * dateless task has no day to credit (the wire Todo carries no completedAt to
+ * attribute it after the fact). The composer defaults a due date, so in
+ * practice every linked task is dated.
+ *
+ * Runs from ANY surface that toggles/edits/deletes tasks (plan cards and the
+ * Tasks page alike) and writes through the plan's shared day-write pipeline,
+ * so it composes with — never races — the plan view's debounced edits.
+ */
+
+export interface HabitSyncTarget {
+  habitId: string;
+  date: string;
+}
+
+/** The (habit, day) pairs a todo's state change can affect. */
+export function habitSyncTargets(...todos: (Todo | undefined | null)[]): HabitSyncTarget[] {
+  const seen = new Set<string>();
+  const targets: HabitSyncTarget[] = [];
+  for (const todo of todos) {
+    if (!todo?.habitId || !todo.dueDate) continue;
+    const key = `${todo.habitId}|${todo.dueDate}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    targets.push({ habitId: todo.habitId, date: todo.dueDate });
+  }
+  return targets;
+}
+
+/** The recompute rule, pure: next mark for (habit, day) given the day's tasks. */
+export function recomputeHabitMark(
+  current: HabitMark | undefined,
+  todos: readonly Todo[],
+  habitId: string,
+  date: string,
+): HabitMark | undefined {
+  const anyDone = todos.some(
+    (t) => !t.archived && t.habitId === habitId && t.dueDate === date && t.isCompleted,
+  );
+  if (anyDone) return true;
+  // Only a task-earnable ✓ is cleared; manual 'skip' (and explicit ✗) stand.
+  return current === true ? undefined : current;
+}
+
+async function loadDay(
+  queryClient: QueryClient,
+  mode: string,
+  planApi: PlanApi,
+  date: string,
+): Promise<DailyPlanData> {
+  // Prefer the live week cache (includes any pending optimistic edits).
+  const week = queryClient.getQueryData<DailyPlanDay[]>(['daily-plan', mode, weekStartOf(date)]);
+  const cached = week?.find((row) => row.date === date);
+  if (cached) return cached.data;
+  const rows = await planApi.fetchRange(date, date);
+  const stored = rows.find((row) => row.date === date);
+  if (stored) return stored.data;
+  // Absent day: materialize from templates exactly like the plan view would,
+  // so storing a habit mark doesn't suppress that day's template prefill.
+  const settings =
+    queryClient.getQueryData<DailyPlanSettings>(['daily-plan-settings', mode]) ??
+    dailyPlanSettingsSchema.parse(await planApi.fetchSettings());
+  return materializeNewDay(settings, date);
+}
+
+async function syncOne(
+  queryClient: QueryClient,
+  mode: string,
+  planApi: PlanApi,
+  target: HabitSyncTarget,
+  todos: readonly Todo[],
+): Promise<void> {
+  const day = await loadDay(queryClient, mode, planApi, target.date);
+  const current = day.habits[target.habitId];
+  const next = recomputeHabitMark(current, todos, target.habitId, target.date);
+  if (next === current) return;
+  const habits = { ...day.habits };
+  if (next === undefined) delete habits[target.habitId];
+  else habits[target.habitId] = next;
+  writePlanDayImmediate(queryClient, mode, planApi, target.date, { ...day, habits });
+}
+
+/**
+ * Recompute + persist habit marks for the given targets. `changed` carries the
+ * row(s) the triggering mutation just wrote — merged over the base list so the
+ * rule always sees the state it was triggered by, even if the list cache is
+ * cold. Guest mode reads storage truth; server mode reads the todos cache
+ * (always populated before any task UI exists). Fire-and-forget; failures are
+ * swallowed (the next linked-task event recomputes, so state self-heals).
+ */
+export function useHabitTaskSync() {
+  const { guestMode } = useAuth();
+  const queryClient = useQueryClient();
+  return useCallback(
+    (targets: readonly HabitSyncTarget[], changed: readonly Todo[]) => {
+      if (targets.length === 0) return;
+      const mode = guestMode ? 'guest' : 'server';
+      const planApi = guestMode ? localPlanApi : serverPlanApi;
+      void (async () => {
+        const base = guestMode
+          ? await guestApi.fetchTodos()
+          : (queryClient.getQueryData<Todo[]>(todosQueryKey(guestMode)) ?? []);
+        const changedIds = new Set(changed.map((t) => t.id));
+        const todos = [...base.filter((t) => !changedIds.has(t.id)), ...changed];
+        for (const target of targets) {
+          await syncOne(queryClient, mode, planApi, target, todos);
+        }
+      })().catch(() => {
+        // Self-healing by design — see docstring.
+      });
+    },
+    [guestMode, queryClient],
+  );
+}

--- a/apps/web/src/features/daily-plan/data/hooks.ts
+++ b/apps/web/src/features/daily-plan/data/hooks.ts
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
-import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  keepPreviousData,
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+} from '@tanstack/react-query';
 import {
   defaultDailyPlanSettings,
   extractDayMetrics,
@@ -190,6 +195,131 @@ export function usePlanMetrics(range: { startDate: string; endDate: string }) {
   };
 }
 
+/* ── shared day-write pipeline ────────────────────────────────────────────────
+ * ONE pending snapshot per (mode, date) at module level, so every writer —
+ * the plan view's debounced edits AND out-of-view writers like the task→habit
+ * sync — composes from the same cache state and flushes through the same
+ * queue. Two independent pipelines racing the same date could PUT snapshots
+ * that silently drop each other's changes. */
+
+interface PendingDayWrite {
+  planApi: PlanApi;
+  mode: string;
+  date: string;
+  data: DailyPlanData;
+}
+
+const dayWriteTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const dayWritePending = new Map<string, PendingDayWrite>();
+
+const dayWriteKey = (mode: string, date: string) => `${mode}|${date}`;
+
+function flushDayWrite(key: string, queryClient?: QueryClient) {
+  const timer = dayWriteTimers.get(key);
+  if (timer) clearTimeout(timer);
+  dayWriteTimers.delete(key);
+  const entry = dayWritePending.get(key);
+  if (!entry) return;
+  dayWritePending.delete(key);
+  entry.planApi
+    .putDay(entry.date, entry.data)
+    .then(() => markSettled(`day:${entry.date}`, true))
+    .catch(() => {
+      markSettled(`day:${entry.date}`, false);
+      // Server rejected/failed — refetch the truth for that week.
+      void queryClient?.invalidateQueries({
+        queryKey: weekKey(entry.mode, weekStartOf(entry.date)),
+      });
+    });
+}
+
+/** Patch every read-model cache (week, recent windows, metrics) for one day. */
+function patchDayCaches(queryClient: QueryClient, mode: string, date: string, next: DailyPlanData) {
+  const upsert = (rows: DailyPlanDay[] | undefined): DailyPlanDay[] => {
+    const list = rows ? [...rows] : [];
+    const index = list.findIndex((row) => row.date === date);
+    if (index === -1) {
+      list.push({ date, data: next });
+      list.sort((a, b) => a.date.localeCompare(b.date));
+    } else {
+      list[index] = { date, data: next };
+    }
+    return list;
+  };
+  queryClient.setQueryData<DailyPlanDay[]>(weekKey(mode, weekStartOf(date)), upsert);
+  // Keep recent-days windows fresh too, so same-session edits to a past
+  // day (e.g. yesterday's Tomorrow Plan) flow straight into today's
+  // continuity/suggestions instead of waiting out staleTime.
+  queryClient.setQueriesData<DailyPlanDay[]>(
+    {
+      predicate: (query) => {
+        const key = query.queryKey;
+        return (
+          Array.isArray(key) &&
+          key[0] === 'daily-plan-recent' &&
+          key[1] === mode &&
+          typeof key[2] === 'string' &&
+          typeof key[3] === 'string' &&
+          key[2] <= date &&
+          date <= key[3]
+        );
+      },
+    },
+    upsert,
+  );
+  // Statistics metrics caches covering this date update too — the shared
+  // extractor makes today's edits show up in charts without a refetch.
+  queryClient.setQueriesData<PlanMetricsResponse>(
+    {
+      predicate: (query) => {
+        const key = query.queryKey;
+        return (
+          Array.isArray(key) &&
+          key[0] === 'plan-metrics' &&
+          key[1] === mode &&
+          typeof key[2] === 'string' &&
+          typeof key[3] === 'string' &&
+          key[2] <= date &&
+          date <= key[3]
+        );
+      },
+    },
+    (response) => {
+      if (!response) return response;
+      const metric = extractDayMetrics(date, next);
+      const items = [...response.items];
+      const index = items.findIndex((m) => m.date === date);
+      if (index === -1) {
+        items.push(metric);
+        items.sort((a, b) => a.date.localeCompare(b.date));
+      } else {
+        items[index] = metric;
+      }
+      return { items };
+    },
+  );
+}
+
+/**
+ * Immediate write-through for out-of-view writers (task→habit sync): patches
+ * the caches, takes over any pending debounced snapshot for the date (the
+ * caller composed `next` from the cache, which already contains it), and PUTs
+ * right away — no debounce, since these are single event-driven writes.
+ */
+export function writePlanDayImmediate(
+  queryClient: QueryClient,
+  mode: string,
+  planApi: PlanApi,
+  date: string,
+  next: DailyPlanData,
+) {
+  patchDayCaches(queryClient, mode, date, next);
+  const key = dayWriteKey(mode, date);
+  dayWritePending.set(key, { planApi, mode, date, data: next });
+  markDirty(`day:${date}`);
+  flushDayWrite(key, queryClient);
+}
+
 /**
  * Debounced day writer. `saveDay(date, next)` patches the week cache
  * immediately and schedules the PUT; pending writes flush on unmount.
@@ -197,46 +327,13 @@ export function usePlanMetrics(range: { startDate: string; endDate: string }) {
 export function useSaveDay() {
   const { planApi, mode } = usePlanApi();
   const queryClient = useQueryClient();
-  const timers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
-  const pending = useRef(new Map<string, DailyPlanData>());
-
-  const flush = useCallback(
-    (date: string) => {
-      const timer = timers.current.get(date);
-      if (timer) clearTimeout(timer);
-      timers.current.delete(date);
-      const data = pending.current.get(date);
-      if (!data) return;
-      pending.current.delete(date);
-      planApi
-        .putDay(date, data)
-        .then(() => markSettled(`day:${date}`, true))
-        .catch(() => {
-          markSettled(`day:${date}`, false);
-          // Server rejected/failed — refetch the truth for that week.
-          void queryClient.invalidateQueries({ queryKey: weekKey(mode, weekStartOf(date)) });
-        });
-    },
-    [planApi, queryClient, mode],
-  );
 
   useEffect(() => {
-    const timerMap = timers.current;
-    const pendingMap = pending.current;
     // Refresh/close/app-switch would silently drop the 800ms debounce window:
     // React cleanups do not run on unload. Flush everything the moment the
     // page hides (the PUTs are keepalive, so they outlive a closing tab).
     const flushAll = () => {
-      for (const [date, data] of pendingMap) {
-        const timer = timerMap.get(date);
-        if (timer) clearTimeout(timer);
-        timerMap.delete(date);
-        void planApi
-          .putDay(date, data)
-          .then(() => markSettled(`day:${date}`, true))
-          .catch(() => markSettled(`day:${date}`, false));
-      }
-      pendingMap.clear();
+      for (const key of [...dayWritePending.keys()]) flushDayWrite(key, queryClient);
     };
     const onHide = () => {
       if (document.visibilityState === 'hidden') flushAll();
@@ -246,94 +343,25 @@ export function useSaveDay() {
     return () => {
       window.removeEventListener('pagehide', flushAll);
       document.removeEventListener('visibilitychange', onHide);
-      for (const timer of timerMap.values()) clearTimeout(timer);
-      timerMap.clear();
       // Fire-and-forget the unsaved blobs so day/mode switches never lose data.
-      for (const [date, data] of pendingMap) {
-        void planApi
-          .putDay(date, data)
-          .then(() => markSettled(`day:${date}`, true))
-          .catch(() => markSettled(`day:${date}`, false));
-      }
-      pendingMap.clear();
+      flushAll();
     };
-  }, [planApi]);
+  }, [queryClient]);
 
   return useCallback(
     (date: string, next: DailyPlanData) => {
-      const upsert = (rows: DailyPlanDay[] | undefined): DailyPlanDay[] => {
-        const list = rows ? [...rows] : [];
-        const index = list.findIndex((row) => row.date === date);
-        if (index === -1) {
-          list.push({ date, data: next });
-          list.sort((a, b) => a.date.localeCompare(b.date));
-        } else {
-          list[index] = { date, data: next };
-        }
-        return list;
-      };
-      queryClient.setQueryData<DailyPlanDay[]>(weekKey(mode, weekStartOf(date)), upsert);
-      // Keep recent-days windows fresh too, so same-session edits to a past
-      // day (e.g. yesterday's Tomorrow Plan) flow straight into today's
-      // continuity/suggestions instead of waiting out staleTime.
-      queryClient.setQueriesData<DailyPlanDay[]>(
-        {
-          predicate: (query) => {
-            const key = query.queryKey;
-            return (
-              Array.isArray(key) &&
-              key[0] === 'daily-plan-recent' &&
-              key[1] === mode &&
-              typeof key[2] === 'string' &&
-              typeof key[3] === 'string' &&
-              key[2] <= date &&
-              date <= key[3]
-            );
-          },
-        },
-        upsert,
-      );
-      // Statistics metrics caches covering this date update too — the shared
-      // extractor makes today's edits show up in charts without a refetch.
-      queryClient.setQueriesData<PlanMetricsResponse>(
-        {
-          predicate: (query) => {
-            const key = query.queryKey;
-            return (
-              Array.isArray(key) &&
-              key[0] === 'plan-metrics' &&
-              key[1] === mode &&
-              typeof key[2] === 'string' &&
-              typeof key[3] === 'string' &&
-              key[2] <= date &&
-              date <= key[3]
-            );
-          },
-        },
-        (response) => {
-          if (!response) return response;
-          const metric = extractDayMetrics(date, next);
-          const items = [...response.items];
-          const index = items.findIndex((m) => m.date === date);
-          if (index === -1) {
-            items.push(metric);
-            items.sort((a, b) => a.date.localeCompare(b.date));
-          } else {
-            items[index] = metric;
-          }
-          return { items };
-        },
-      );
-      pending.current.set(date, next);
+      patchDayCaches(queryClient, mode, date, next);
+      const key = dayWriteKey(mode, date);
+      dayWritePending.set(key, { planApi, mode, date, data: next });
       markDirty(`day:${date}`);
-      const existing = timers.current.get(date);
+      const existing = dayWriteTimers.get(key);
       if (existing) clearTimeout(existing);
-      timers.current.set(
-        date,
-        setTimeout(() => flush(date), PLAN_SAVE_DEBOUNCE_MS),
+      dayWriteTimers.set(
+        key,
+        setTimeout(() => flushDayWrite(key, queryClient), PLAN_SAVE_DEBOUNCE_MS),
       );
     },
-    [queryClient, mode, flush],
+    [queryClient, mode, planApi],
   );
 }
 

--- a/apps/web/src/features/settings/export-import-lib.ts
+++ b/apps/web/src/features/settings/export-import-lib.ts
@@ -116,6 +116,7 @@ function normalizeTodo(raw: unknown, taskNumber: number): Todo | null {
     // Preserved when it parses as a plausible rule (has a mode/type string) —
     // the same tolerance as the server import; anything else becomes null.
     recurrence: plausibleRecurrence(record.recurrence),
+    habitId: str(pick(record, 'habitId', 'habit_id')),
     originalId: str(pick(record, 'originalId', 'original_id')),
     archived: false,
     createdAt: str(pick(record, 'createdAt', 'created_at')) ?? now,

--- a/apps/web/src/features/todos/components/Composer.tsx
+++ b/apps/web/src/features/todos/components/Composer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { FormEvent, MouseEvent as ReactMouseEvent } from 'react';
-import type { CreateTodoInput, Priority, Recurrence, Tag, Todo } from '@lifeline/shared';
+import type { CreateTodoInput, PlanHabit, Priority, Recurrence, Tag, Todo } from '@lifeline/shared';
 import { FlagIcon } from '../../../shared/ui/icons';
 import { useCreateTag, useCreateTodo, useSimilar, useTodoByNumber } from '../data/hooks';
 import { resolveDayString } from '../lib/day-filter';
@@ -42,6 +42,12 @@ export interface ComposerProps {
    * typing right after "+ ADD TASK" lands in the task name.
    */
   initialFocus?: 'load' | 'title' | undefined;
+  /**
+   * Daily Plan habits offered by the "Counts toward habit" select. Completing
+   * the created task checks the linked habit for the task's due date. Absent/
+   * empty hides the control entirely.
+   */
+  habits?: readonly PlanHabit[] | undefined;
 }
 
 interface DraftSubtask {
@@ -63,6 +69,7 @@ export function Composer({
   initialDueTime,
   closeOnOutsideClick = true,
   initialFocus = 'load',
+  habits,
 }: ComposerProps) {
   const formRef = useRef<HTMLFormElement | null>(null);
   const loadInputRef = useRef<HTMLInputElement | null>(null);
@@ -88,6 +95,7 @@ export function Composer({
     }
   }
   const [priority, setPriority] = useState<Priority>('medium');
+  const [habitId, setHabitId] = useState('');
   const [isFlagged, setIsFlagged] = useState(false);
   const [tagIds, setTagIds] = useState<string[]>([]);
   const [showTagPicker, setShowTagPicker] = useState(false);
@@ -158,6 +166,7 @@ export function Composer({
     setDueTime(initialDueTime ?? '');
     setScheduleDate(initialDueDate ?? '');
     setPriority('medium');
+    setHabitId('');
     setIsFlagged(false);
     setTagIds([]);
     setShowTagPicker(false);
@@ -191,6 +200,8 @@ export function Composer({
     setTagIds(todo.tags.map((tag) => tag.id));
     setIsFlagged(todo.isFlagged);
     setPriority(todo.priority);
+    // A template of a linked task carries its habit link onto the new task.
+    setHabitId(todo.habitId ?? '');
     setSubtasks(
       todo.subtasks.map((subtask) => ({
         key: subtask.subtaskId,
@@ -251,6 +262,7 @@ export function Composer({
         isCompleted: subtask.isCompleted,
       })),
       recurrence,
+      habitId: habitId || null,
     };
     try {
       await createTodo.mutateAsync(input);
@@ -526,6 +538,23 @@ export function Composer({
           <option value="medium">Medium Priority</option>
           <option value="high">High Priority</option>
         </select>
+
+        {habits && habits.length > 0 && (
+          <select
+            className={styles.control}
+            value={habitId}
+            onChange={(event) => setHabitId(event.target.value)}
+            aria-label="Counts toward habit"
+            title="Completing this task checks the habit for that day"
+          >
+            <option value="">No habit</option>
+            {habits.map((habit) => (
+              <option key={habit.id} value={habit.id}>
+                ✓ {habit.label}
+              </option>
+            ))}
+          </select>
+        )}
 
         <button
           type="button"

--- a/apps/web/src/features/todos/components/composer.test.tsx
+++ b/apps/web/src/features/todos/components/composer.test.tsx
@@ -57,6 +57,7 @@ describe('Composer submit payload', () => {
       priority: 'high',
       subtasks: [{ title: 'Write agenda', isCompleted: false }],
       recurrence: null,
+      habitId: null,
     });
   });
 

--- a/apps/web/src/features/todos/data/hooks.ts
+++ b/apps/web/src/features/todos/data/hooks.ts
@@ -13,6 +13,8 @@ import type {
 import { guestApi } from '../../../shared/guest/guest-api';
 import type { GuestTodoPatch } from '../../../shared/guest/guest-api';
 import { useAuth } from '../../../app/providers/auth-context';
+import { habitSyncTargets, useHabitTaskSync } from '../../daily-plan/data/habit-task-sync';
+import { todosQueryKey, tagsQueryKey } from './keys';
 import { moveById, computeOrderPatches } from '../lib/reorder';
 import type { OrderPatch } from '../lib/reorder';
 import * as todosApi from './api';
@@ -33,8 +35,7 @@ import * as todosApi from './api';
 
 const MAX_PAGES = 50;
 
-export const todosQueryKey = (guest: boolean) => ['todos', guest ? 'guest' : 'server'] as const;
-export const tagsQueryKey = (guest: boolean) => ['tags', guest ? 'guest' : 'server'] as const;
+export { todosQueryKey, tagsQueryKey };
 
 async function fetchAllServerTodos(): Promise<Todo[]> {
   const items: Todo[] = [];
@@ -130,11 +131,18 @@ export function useCreateTodo() {
 
 export function useUpdateTodo() {
   const { guestMode } = useAuth();
-  const { replaceTodo } = useTodoCache();
+  const { queryClient, key, replaceTodo } = useTodoCache();
+  const syncHabits = useHabitTaskSync();
   return useMutation({
     mutationFn: ({ id, patch }: { id: string; patch: UpdateTodoInput }) =>
       guestMode ? guestApi.updateTodo(id, patch as GuestTodoPatch) : todosApi.patchTodo(id, patch),
-    onSuccess: (updated) => replaceTodo(updated),
+    onSuccess: (updated) => {
+      // A completed linked task moved to another day (or re-linked) must
+      // recompute BOTH sides — the old day's ✓ may no longer be earned.
+      const before = queryClient.getQueryData<Todo[]>(key)?.find((t) => t.id === updated.id);
+      replaceTodo(updated);
+      syncHabits(habitSyncTargets(before, updated), [updated]);
+    },
   });
 }
 
@@ -142,6 +150,7 @@ export function useUpdateTodo() {
 export function useToggleComplete() {
   const { guestMode } = useAuth();
   const { replaceTodo } = useTodoCache();
+  const syncHabits = useHabitTaskSync();
   return useMutation({
     mutationFn: async ({ id, isCompleted }: { id: string; isCompleted: boolean }) => {
       if (guestMode) return guestApi.toggleTodo(id);
@@ -150,7 +159,11 @@ export function useToggleComplete() {
         : todosApi.completeTodo(id));
       return todo;
     },
-    onSuccess: (todo) => replaceTodo(todo),
+    onSuccess: (todo) => {
+      replaceTodo(todo);
+      // Linked task toggled → recompute its habit's ✓ for the task's day.
+      syncHabits(habitSyncTargets(todo), [todo]);
+    },
   });
 }
 
@@ -167,10 +180,18 @@ export function useToggleFlag() {
 /** DELETE = archive on the server; guest deletion is permanent (old behavior). */
 export function useDeleteTodo() {
   const { guestMode } = useAuth();
-  const { removeTodo } = useTodoCache();
+  const { queryClient, key, removeTodo } = useTodoCache();
+  const syncHabits = useHabitTaskSync();
   return useMutation({
     mutationFn: (id: string) => (guestMode ? guestApi.deleteTodo(id) : todosApi.archiveTodo(id)),
-    onSuccess: (_result, id) => removeTodo(id),
+    onSuccess: (_result, id) => {
+      // Deleting a completed linked task may un-earn its habit's ✓ (guest
+      // deletion is already gone from storage truth; server archive drops it
+      // from the recompute via the archived flag on the refetched row).
+      const before = queryClient.getQueryData<Todo[]>(key)?.find((t) => t.id === id);
+      removeTodo(id);
+      syncHabits(habitSyncTargets(before), before ? [{ ...before, archived: true }] : []);
+    },
   });
 }
 
@@ -286,6 +307,7 @@ export type BatchAction = 'complete' | 'uncomplete' | 'archive' | 'restore';
 export function useBatch() {
   const { guestMode } = useAuth();
   const { queryClient, key, invalidate } = useTodoCache();
+  const syncHabits = useHabitTaskSync();
   return useMutation<BatchResult | null, Error, { action: BatchAction; ids: string[] }>({
     mutationFn: async ({ action, ids }) => {
       if (!guestMode) return todosApi.batchTodos({ action, ids });
@@ -301,7 +323,16 @@ export function useBatch() {
       }
       return null;
     },
-    onSuccess: () => void invalidate(),
+    onSuccess: async (_result, { ids }) => {
+      // Batch complete/uncomplete/archive can flip linked tasks — collect the
+      // affected (habit, day) pairs first (link/date don't change in a batch),
+      // then recompute against the refreshed list (guest reads storage truth;
+      // server relies on the invalidated query's refetch).
+      const idSet = new Set(ids);
+      const affected = (queryClient.getQueryData<Todo[]>(key) ?? []).filter((t) => idSet.has(t.id));
+      await invalidate();
+      syncHabits(habitSyncTargets(...affected), []);
+    },
   });
 }
 

--- a/apps/web/src/features/todos/data/keys.ts
+++ b/apps/web/src/features/todos/data/keys.ts
@@ -1,0 +1,5 @@
+/** Query keys shared by the todos hooks and cross-feature consumers (the
+ * daily-plan habit sync) — a separate module so neither side imports the
+ * other's hooks. */
+export const todosQueryKey = (guest: boolean) => ['todos', guest ? 'guest' : 'server'] as const;
+export const tagsQueryKey = (guest: boolean) => ['tags', guest ? 'guest' : 'server'] as const;

--- a/apps/web/src/shared/guest/guest-api.ts
+++ b/apps/web/src/shared/guest/guest-api.ts
@@ -66,6 +66,7 @@ export interface GuestTodoPatch {
   priority?: Todo['priority'];
   subtasks?: SubtaskInput[];
   order?: number;
+  habitId?: string | null;
 }
 
 export interface GuestApi {
@@ -228,6 +229,7 @@ function normalizeStoredTodo(value: unknown): Todo | null {
   const priority = record.priority;
   const description = usableTitle(record.description);
   const originalId = pickField(record, 'originalId', 'original_id');
+  const habitId = pickField(record, 'habitId', 'habit_id');
 
   const subtasks: Subtask[] = [];
   for (const raw of Array.isArray(record.subtasks) ? record.subtasks : []) {
@@ -262,6 +264,7 @@ function normalizeStoredTodo(value: unknown): Todo | null {
     subtasks,
     order: Number.isFinite(order) ? Math.round(order) : 0,
     recurrence: plausibleRecurrence(record.recurrence),
+    habitId: typeof habitId === 'string' && habitId.length > 0 ? habitId : null,
     originalId: typeof originalId === 'string' && originalId.length > 0 ? originalId : null,
     archived: Boolean(record.archived),
     createdAt: isoOrNow(pickField(record, 'createdAt', 'created_at'), now),
@@ -464,6 +467,9 @@ export function createGuestApi(storage: GuestStorage = browserStorage): GuestApi
           subtasks: subtasks.map((subtask) => ({ ...subtask })),
           order: 0,
           recurrence,
+          // The habit link rides on every expanded occurrence (recurring task
+          // → drives its habit each day), mirroring the server expansion.
+          habitId: input.habitId ?? null,
           originalId: null,
           archived: false,
           createdAt: now,
@@ -501,6 +507,7 @@ export function createGuestApi(storage: GuestStorage = browserStorage): GuestApi
       if (patch.duration !== undefined) next.duration = patch.duration;
       if (patch.priority !== undefined) next.priority = patch.priority;
       if (patch.order !== undefined) next.order = patch.order;
+      if (patch.habitId !== undefined) next.habitId = patch.habitId;
       if (patch.tags !== undefined) next.tags = resolveTags(patch.tags);
       if (patch.subtasks !== undefined) next.subtasks = normalizeSubtasks(patch.subtasks);
 

--- a/apps/web/src/test/test-utils.ts
+++ b/apps/web/src/test/test-utils.ts
@@ -56,6 +56,7 @@ export function makeTodo(overrides: Partial<Todo> = {}): Todo {
     subtasks: [],
     order: 0,
     recurrence: null,
+    habitId: null,
     originalId: null,
     archived: false,
     createdAt: now,

--- a/packages/shared/src/todo.test.ts
+++ b/packages/shared/src/todo.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { listTodosQuerySchema, queryBooleanSchema } from './todo.js';
+import {
+  createTodoSchema,
+  listTodosQuerySchema,
+  queryBooleanSchema,
+  updateTodoSchema,
+} from './todo.js';
 
 /**
  * Regression: `flagged`/`includeArchived` used `z.coerce.boolean()`, which is
@@ -60,5 +65,19 @@ describe('listTodosQuerySchema — flagged / includeArchived coercion', () => {
 
   it('invalid boolean string is a validation error', () => {
     expect(() => listTodosQuerySchema.parse({ flagged: 'maybe' })).toThrow();
+  });
+});
+
+describe('habitId (task ↔ habit link)', () => {
+  it('create accepts a habit link and defaults to none', () => {
+    expect(createTodoSchema.parse({ title: 'Udemy hour', habitId: 'udemy' }).habitId).toBe('udemy');
+    expect(createTodoSchema.parse({ title: 'Plain task' }).habitId).toBeUndefined();
+    // Bounded — a habit id is a short slug, not free text.
+    expect(createTodoSchema.safeParse({ title: 'x', habitId: 'h'.repeat(65) }).success).toBe(false);
+  });
+
+  it('update can set and clear the link', () => {
+    expect(updateTodoSchema.parse({ habitId: 'udemy' }).habitId).toBe('udemy');
+    expect(updateTodoSchema.parse({ habitId: null }).habitId).toBeNull();
   });
 });

--- a/packages/shared/src/todo.ts
+++ b/packages/shared/src/todo.ts
@@ -66,6 +66,9 @@ export const todoSchema = z.object({
   subtasks: z.array(subtaskSchema),
   order: z.number().int(),
   recurrence: recurrenceSchema.nullable(),
+  /** Habit this task counts toward (Daily Plan habit id); completing the task
+      checks that habit for the task's due date. Default so old rows self-heal. */
+  habitId: z.string().min(1).max(64).nullable().default(null),
   originalId: z.string().nullable(),
   archived: z.boolean(),
   createdAt: z.iso.datetime({ offset: true }),
@@ -100,6 +103,7 @@ export const createTodoSchema = z.object({
   priority: prioritySchema.optional(),
   subtasks: z.array(subtaskInputSchema).max(LIMITS.subtasksPerTodoMax).optional(),
   recurrence: recurrenceSchema.nullish(),
+  habitId: z.string().min(1).max(64).nullish(),
 });
 export type CreateTodoInput = z.infer<typeof createTodoSchema>;
 


### PR DESCRIPTION
## Summary

A task can now **count toward a habit**: create (or edit) a task, pick a habit in the new **"Counts toward habit"** select, and completing that task **checks the habit for the task's day**.

**The rule that keeps multiple tasks per habit coherent.** The habit's check is *earned by rule*, not fired as a one-shot event. On every linked-task change we recompute: *is any linked task due that day completed?*

| You do… | Habit that day |
|---|---|
| Complete udemy task A | ✓ |
| Complete udemy task B too | stays ✓ (no double-count) |
| Un-complete A (B still done) | **stays ✓** |
| Un-complete both | unchecks (streaks stay honest) |
| Move a completed task to another day | old day un-earns, new day earns |
| Delete a completed linked task | its day recomputes |

Manual habit taps stay free: only an **earned ✓** is ever auto-cleared — a manual *skip*/✗ stands — and days without linked-task activity are never touched. The sync is strictly one-way (habit taps never complete tasks). **Recurring tasks carry the link on every occurrence**, so a recurring "1h Udemy" task drives the habit daily. Templates (load-by-# / suggestions) carry the link onto the new task.

**Where it works:** the sync runs from the plan cards *and* the Tasks page (it hooks the shared toggle/update/delete/batch mutations). Writes go through the plan's day-write pipeline — refactored to one module-level pending queue (`writePlanDayImmediate`) — so a sync write **composes with, never races,** the plan view's debounced edits. Absent days materialize from the user's weekday template first, so a habit write never suppresses that day's template prefill. Streaks, score, and statistics need zero changes — real habit marks are written.

**Storage:** additive `habitId` on todos end-to-end — shared zod schemas, server column + hand-authored idempotent migration (`0002_todo_habit_id.sql`), create/update use-cases (copied to every expanded recurrence row), repository, guest localStorage adapter, export/import. Old rows read as null (no link).

**Verified live in-browser** (guest, phone viewport): created "1 hour Udemy course" linked to the udemy habit via the composer select → completed it in the To-Do card → the **"1 Hour Udemy" habit cell filled for today** (`{"udemy":true}` persisted on the day blob); un-completing cleared it; the preview popup shows and edits the link. Suites green: **web 294** (incl. new rule-unit + end-to-end component suites), **server 370** (incl. router roundtrip + recurrence-copy), **shared 44**; lint, prettier, typecheck clean; web + server production builds pass.

## Change Type
- [x] Product behavior
- [x] Feature scope
- [x] Frontend behavior
- [x] Backend behavior
- [x] API contract
- [x] Data model
- [ ] Architecture
- [ ] Operations / deployment

## Documentation Impact
- [x] I evaluated documentation impact.
- [ ] I updated the relevant docs.
- [x] No docs update was needed, and I explained why below.

## Docs Updated

None.

## If no docs were updated, explain why

The API change is a single additive, optional field (`habitId`) on the existing todo schemas — documented automatically through the shared zod schemas that feed the OpenAPI registry. The migration is additive and idempotent (`ADD COLUMN IF NOT EXISTS`), matching the repo's convention; no operational procedure changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV)_