### PR TITLE
feat(plan): 12h/24h clock toggle + a clear "not today" indicator

### DIFF
--- a/apps/web/src/app/pages/DashboardPage.tsx
+++ b/apps/web/src/app/pages/DashboardPage.tsx
@@ -28,6 +28,7 @@ import { formatDuration } from '../../features/todos/lib/format';
 import { DailyPlanView } from '../../features/daily-plan/DailyPlanView';
 import { usePlanSettings } from '../../features/daily-plan/data/hooks';
 import { useHomeViewMode } from '../../features/daily-plan/data/view-mode';
+import { dayRouteToken } from '../../features/search/search-lib';
 import { ApiError } from '../../shared/api/client';
 import { SparklesIcon } from '../../shared/ui/icons';
 import { Spinner } from '../../shared/ui/Spinner';
@@ -255,7 +256,12 @@ export default function DashboardPage() {
   );
 
   const handleSelectPlanDay = useCallback(
-    (date: string) => void navigate(`/day/${date}`),
+    (date: string) => {
+      // Collapse today → the canonical '/' route (so "Go to today" lands on the
+      // home URL, not /day/<today's date>); other days keep their dated route.
+      const token = dayRouteToken(date);
+      void navigate(token === 'today' ? '/' : `/day/${date}`);
+    },
     [navigate],
   );
 

--- a/apps/web/src/features/daily-plan/DailyPlan.module.css
+++ b/apps/web/src/features/daily-plan/DailyPlan.module.css
@@ -236,6 +236,7 @@
 }
 
 .weekChip {
+  position: relative;
   width: 24px;
   height: 24px;
   border-radius: 50%;
@@ -247,6 +248,24 @@
   color: var(--plan-muted);
   border: 1px solid var(--plan-rule);
   background: transparent;
+}
+
+/* The REAL current date: a small dot under the chip so the day you're viewing
+   (the filled chip) reads as distinct from today when they differ. */
+.weekChipRealToday {
+  border-color: var(--plan-primary);
+  color: var(--color-text);
+}
+
+.weekChipDot {
+  position: absolute;
+  bottom: -5px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--plan-primary);
 }
 
 /* As a button the chip navigates to that weekday. */
@@ -570,6 +589,47 @@ button.weekChipToday:hover:not(:disabled) {
   .planToast {
     animation: none;
   }
+}
+
+/* Persistent "return to today" pill — bottom-left so it clears the
+   bottom-center JumpSheet pill; only shown while viewing another day. */
+.todayFab {
+  position: fixed;
+  left: calc(14px + env(safe-area-inset-left, 0px));
+  bottom: calc(14px + env(safe-area-inset-bottom, 0px));
+  z-index: 901;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 9px 15px;
+  border-radius: 999px;
+  border: 1px solid var(--plan-primary);
+  background: var(--plan-primary);
+  color: var(--plan-primary-ink);
+  font-family: var(--plan-label-font);
+  font-size: calc(12px * var(--plan-scale, 1));
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.22);
+}
+
+.todayFab:hover {
+  filter: brightness(1.06);
+}
+
+/* Clear the sidebar on desktop, matching the JumpSheet pill's offset. */
+@media (min-width: 769px) {
+  .todayFab {
+    left: calc(var(--sidebar-width) + 14px);
+  }
+}
+
+/* The "you're viewing another day" banner — tinted so it reads as a state,
+   not an error. */
+.viewingBar {
+  border-style: solid;
+  border-color: var(--plan-primary);
 }
 
 /* ── jump navigation & internal list scrolling ───────────────────────────── */

--- a/apps/web/src/features/daily-plan/DailyPlan.module.css
+++ b/apps/web/src/features/daily-plan/DailyPlan.module.css
@@ -591,12 +591,14 @@ button.weekChipToday:hover:not(:disabled) {
   }
 }
 
-/* Persistent "return to today" pill — bottom-left so it clears the
-   bottom-center JumpSheet pill; only shown while viewing another day. */
+/* Persistent "return to today" pill — bottom-left, and lifted to sit ABOVE
+   the bottom-center JumpSheet pill so the two never share the bottom band on
+   narrow phones (the pill owns that row plus its hold-to-glide gesture
+   surface). Only shown while viewing another day. */
 .todayFab {
   position: fixed;
   left: calc(14px + env(safe-area-inset-left, 0px));
-  bottom: calc(14px + env(safe-area-inset-bottom, 0px));
+  bottom: calc(66px + env(safe-area-inset-bottom, 0px));
   z-index: 901;
   display: inline-flex;
   align-items: center;
@@ -618,10 +620,12 @@ button.weekChipToday:hover:not(:disabled) {
   filter: brightness(1.06);
 }
 
-/* Clear the sidebar on desktop, matching the JumpSheet pill's offset. */
+/* On desktop the sidebar pushes the centered JumpSheet pill clear of the
+   far-left fab, so it can return to the bottom edge, left of the content. */
 @media (min-width: 769px) {
   .todayFab {
     left: calc(var(--sidebar-width) + 14px);
+    bottom: calc(14px + env(safe-area-inset-bottom, 0px));
   }
 }
 

--- a/apps/web/src/features/daily-plan/DailyPlanView.tsx
+++ b/apps/web/src/features/daily-plan/DailyPlanView.tsx
@@ -295,7 +295,15 @@ export function DailyPlanView({
   // outcome (Add or Dismiss) so the bar never re-offers after a reload.
   // Offered on TODAY only — on other days "yesterday" isn't yesterday, and
   // on the tomorrow view the bar would invite duplicating in-progress work.
-  const isToday = dateStr === resolveDayString('today');
+  const todayStr = resolveDayString('today');
+  const isToday = dateStr === todayStr;
+  // Human label for the day you're viewing when it isn't today.
+  const viewingLabel =
+    dateStr === daysBefore(todayStr, 1)
+      ? 'Yesterday'
+      : dateStr === daysAfter(todayStr, 1)
+        ? 'Tomorrow'
+        : format(parseISO(dateStr), 'EEE, MMM d');
   const carry = useMemo(() => carryOverFrom(yesterday), [yesterday]);
   const [carryError, setCarryError] = useState(false);
 
@@ -739,6 +747,7 @@ export function DailyPlanView({
           day={day}
           patch={patchDay}
           startHour={settings.dayStartHour}
+          timeFormat={settings.timeFormat}
           endHour={settings.dayEndHour}
           suggestionsFor={suggestionsForHour}
           todos={dayTodos}
@@ -785,6 +794,7 @@ export function DailyPlanView({
           historyFor={historyFor}
           prayerTimes={prayerTimes}
           prayerActive={prayerActive}
+          timeFormat={settings.timeFormat}
         />
       ),
     },
@@ -986,7 +996,20 @@ export function DailyPlanView({
         subtitle={settings.subtitle}
         onSelectDay={onSelectDay}
         energy={mastheadEnergy}
+        todayStr={todayStr}
       />
+
+      {!isToday && onSelectDay && (
+        <div className={`${styles.hiddenBar} ${styles.viewingBar}`} role="status">
+          <span className={styles.hiddenBarLabel}>Viewing</span>
+          <span style={{ fontSize: 'calc(12px * var(--plan-scale, 1))' }}>
+            {viewingLabel} — not today
+          </span>
+          <button type="button" className={styles.hiddenChip} onClick={() => onSelectDay(todayStr)}>
+            Go to today →
+          </button>
+        </div>
+      )}
 
       {weekError && !weekReady && (
         <div className={styles.hiddenBar} role="alert">
@@ -1202,12 +1225,24 @@ export function DailyPlanView({
         onMove={moveTask}
         habits={settings.habits}
         onLinkHabit={(todo, habitId) => updateTodo.mutate({ id: todo.id, patch: { habitId } })}
+        timeFormat={settings.timeFormat}
       />
 
       {toast && (
         <div className={styles.planToast} role="status" aria-live="polite">
           {toast}
         </div>
+      )}
+
+      {!isToday && onSelectDay && (
+        <button
+          type="button"
+          className={styles.todayFab}
+          aria-label={`Go to today (viewing ${viewingLabel})`}
+          onClick={() => onSelectDay(todayStr)}
+        >
+          ↩ Today
+        </button>
       )}
 
       <JumpSheet sections={jumpSections} onReorder={reorderVisible} />

--- a/apps/web/src/features/daily-plan/Masthead.tsx
+++ b/apps/web/src/features/daily-plan/Masthead.tsx
@@ -31,12 +31,24 @@ export interface MastheadProps {
   onSelectDay?: ((date: string) => void) | undefined;
   /** Energy summary ring (null hides it — e.g. the Meals card is hidden). */
   energy?: MastheadEnergy | null | undefined;
+  /** The REAL current date ('YYYY-MM-DD') — marks the actual-today chip so it
+      reads distinctly from the SELECTED day when you're browsing another day. */
+  todayStr?: string | undefined;
 }
 
 /** "DAILY PLAN" display header: subtitle rules, date (± day, jump-to-date), week chips, score ring. */
-export function Masthead({ dateStr, score, subtitle, onSelectDay, energy }: MastheadProps) {
-  const todayIdx = weekIndexOf(dateStr);
+export function Masthead({
+  dateStr,
+  score,
+  subtitle,
+  onSelectDay,
+  energy,
+  todayStr,
+}: MastheadProps) {
+  const selIdx = weekIndexOf(dateStr);
   const weekDates = weekDatesOf(dateStr);
+  // Which chip (if any) is the real current date within the displayed week.
+  const realTodayIdx = todayStr ? weekDates.findIndex((d) => d === todayStr) : -1;
   const dash = `${((score / 100) * CIRC).toFixed(1)} ${CIRC.toFixed(1)}`;
   const dateLabel = format(new Date(`${dateStr}T00:00:00`), 'EEEE, MMMM d, yyyy');
   const dateInputRef = useRef<HTMLInputElement | null>(null);
@@ -115,34 +127,45 @@ export function Masthead({ dateStr, score, subtitle, onSelectDay, energy }: Mast
           <div className={styles.dateLabel}>{dateLabel}</div>
         )}
         <div className={styles.weekChips}>
-          {WEEK_LETTERS.map((letter, i) =>
-            onSelectDay ? (
+          {WEEK_LETTERS.map((letter, i) => {
+            // Filled = the day you're VIEWING; a dot = the REAL today (so a
+            // past/other day reads as clearly not-today).
+            const cls = [
+              styles.weekChip,
+              i === selIdx ? styles.weekChipToday : undefined,
+              i === realTodayIdx ? styles.weekChipRealToday : undefined,
+            ]
+              .filter(Boolean)
+              .join(' ');
+            const inner = (
+              <>
+                {letter}
+                {i === realTodayIdx && <span className={styles.weekChipDot} aria-hidden="true" />}
+              </>
+            );
+            const label = `Go to ${WEEK_DAY_NAMES[i] ?? ''} ${weekDates[i] ?? ''}${
+              i === realTodayIdx ? ' (today)' : ''
+            }`;
+            return onSelectDay ? (
               <button
                 key={i}
                 type="button"
-                className={
-                  i === todayIdx ? `${styles.weekChip} ${styles.weekChipToday}` : styles.weekChip
-                }
-                aria-label={`Go to ${WEEK_DAY_NAMES[i] ?? ''} ${weekDates[i] ?? ''}`}
-                aria-current={i === todayIdx ? 'date' : undefined}
+                className={cls}
+                aria-label={label}
+                aria-current={i === realTodayIdx ? 'date' : undefined}
                 onClick={() => {
                   const date = weekDates[i];
-                  if (date && i !== todayIdx) onSelectDay(date);
+                  if (date && i !== selIdx) onSelectDay(date);
                 }}
               >
-                {letter}
+                {inner}
               </button>
             ) : (
-              <span
-                key={i}
-                className={
-                  i === todayIdx ? `${styles.weekChip} ${styles.weekChipToday}` : styles.weekChip
-                }
-              >
-                {letter}
+              <span key={i} className={cls}>
+                {inner}
               </span>
-            ),
-          )}
+            );
+          })}
         </div>
       </div>
       {energy && (

--- a/apps/web/src/features/daily-plan/PlanSettingsModal.tsx
+++ b/apps/web/src/features/daily-plan/PlanSettingsModal.tsx
@@ -5,6 +5,7 @@ import { Modal } from '../../shared/ui/Modal';
 import { CityPicker } from './CityPicker';
 import { templateFromDay } from './lib/templates';
 import { dividerBelowAt, newHabitId, templateKeyOf, withDividerAt } from './lib/plan-model';
+import { formatClock } from './lib/time-format';
 import styles from './DailyPlan.module.css';
 
 /**
@@ -612,6 +613,20 @@ export function PlanSettingsModal(props: PlanSettingsModalProps) {
         <Section title="Schedule & rows">
           <div className={styles.macroGrid}>
             <label className={styles.macroLabel}>
+              TIME FORMAT
+              <select
+                className={styles.smallInput}
+                value={settings.timeFormat}
+                aria-label="Time format"
+                onChange={(e) =>
+                  props.patchSettings({ timeFormat: e.target.value as '24h' | '12h' })
+                }
+              >
+                <option value="24h">24-hour (17:30)</option>
+                <option value="12h">12-hour (5:30 PM)</option>
+              </select>
+            </label>
+            <label className={styles.macroLabel}>
               DAY STARTS
               <select
                 className={styles.smallInput}
@@ -623,7 +638,7 @@ export function PlanSettingsModal(props: PlanSettingsModalProps) {
               >
                 {Array.from({ length: 24 }, (_, h) => (
                   <option key={h} value={h}>
-                    {h < 10 ? `0${h}` : h}:00
+                    {formatClock(`${h < 10 ? '0' : ''}${h}:00`, settings.timeFormat)}
                   </option>
                 ))}
               </select>
@@ -640,9 +655,10 @@ export function PlanSettingsModal(props: PlanSettingsModalProps) {
               >
                 {Array.from({ length: 24 }, (_, i) => {
                   const h = i + 1;
+                  const key = `${h === 24 ? '00' : h < 10 ? `0${h}` : h}:00`;
                   return (
                     <option key={h} value={h}>
-                      {h === 24 ? '00' : h < 10 ? `0${h}` : h}:00
+                      {formatClock(key, settings.timeFormat)}
                     </option>
                   );
                 })}

--- a/apps/web/src/features/daily-plan/TaskPreviewModal.tsx
+++ b/apps/web/src/features/daily-plan/TaskPreviewModal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { addDays, format, parseISO } from 'date-fns';
 import type { PlanHabit, Todo } from '@lifeline/shared';
 import { SquareCheck } from './cards';
+import { formatClock, type TimeFormat } from './lib/time-format';
 import styles from './TaskPreviewModal.module.css';
 
 /**
@@ -51,6 +52,8 @@ export interface TaskPreviewModalProps {
   habits?: readonly PlanHabit[] | undefined;
   /** Link/unlink the task to a habit (null clears the link). */
   onLinkHabit?: ((todo: Todo, habitId: string | null) => void) | undefined;
+  /** 24h vs 12h clock display for the due-time in the meta line. */
+  timeFormat?: TimeFormat | undefined;
 }
 
 export function TaskPreviewModal({
@@ -62,6 +65,7 @@ export function TaskPreviewModal({
   onMove,
   habits,
   onLinkHabit,
+  timeFormat = '24h',
 }: TaskPreviewModalProps) {
   const open = todo !== null;
   useEffect(() => {
@@ -83,9 +87,11 @@ export function TaskPreviewModal({
   const done = todo.subtasks.filter((sub) => sub.isCompleted).length;
   const total = todo.subtasks.length;
   const pct = total > 0 ? Math.round((done / total) * 100) : 0;
-  const meta = [formatDate(todo.dueDate), todo.dueTime, formatDuration(todo.duration)].filter(
-    Boolean,
-  );
+  const meta = [
+    formatDate(todo.dueDate),
+    todo.dueTime ? formatClock(todo.dueTime, timeFormat) : null,
+    formatDuration(todo.duration),
+  ].filter(Boolean);
   const now = new Date();
   const todayStr = format(now, 'yyyy-MM-dd');
   const tomorrowStr = format(addDays(now, 1), 'yyyy-MM-dd');

--- a/apps/web/src/features/daily-plan/cards.tsx
+++ b/apps/web/src/features/daily-plan/cards.tsx
@@ -21,6 +21,7 @@ import {
   toWeightDisplay,
 } from './lib/units';
 import { PRAYER_HABIT_IDS, type DayPrayers, type PrayerKey } from './lib/prayer-times';
+import { formatClock, type TimeFormat } from './lib/time-format';
 import styles from './DailyPlan.module.css';
 
 /**
@@ -226,12 +227,15 @@ export interface ScheduleBodyProps {
   onToggleSubtask?: SubtaskToggle | undefined;
   /** Viewing TODAY: the current hour gets a live band and the list opens on it. */
   isToday?: boolean;
+  /** 24h vs 12h clock display (times are stored 24h regardless). */
+  timeFormat?: TimeFormat;
 }
 
 function SchedChip(props: {
   todo: Todo;
   /** Always show the time (off-hours chips) vs only off-hour minutes. */
   alwaysTime?: boolean;
+  timeFormat: TimeFormat;
   onToggle: () => void;
   onOpen: (todo: Todo) => void;
   onToggleSubtask?: SubtaskToggle | undefined;
@@ -271,7 +275,9 @@ function SchedChip(props: {
             onToggleExpand={() => setExpanded((v) => !v)}
           />
         )}
-        {showTime && <span className={styles.chipTime}>{todo.dueTime}</span>}
+        {showTime && todo.dueTime && (
+          <span className={styles.chipTime}>{formatClock(todo.dueTime, props.timeFormat)}</span>
+        )}
         <TagCluster tags={todo.tags} />
       </div>
       {expandable && expanded && props.onToggleSubtask && (
@@ -295,6 +301,7 @@ export function ScheduleBody({
   onAddTaskAt,
   onToggleSubtask,
   isToday = false,
+  timeFormat = '24h',
 }: ScheduleBodyProps) {
   const hours = scheduleHours(startHour, endHour);
   const byTime = (a: Todo, b: Todo) => (a.dueTime ?? '').localeCompare(b.dueTime ?? '');
@@ -348,13 +355,13 @@ export function ScheduleBody({
                   .join(' ')}
                 {...(isNow ? { 'data-now': '' } : {})}
               >
-                <span className={styles.schedTime}>{time}</span>
+                <span className={styles.schedTime}>{formatClock(time, timeFormat)}</span>
                 <input
                   dir="auto"
                   className={styles.inputBare}
                   maxLength={500}
                   value={day.schedule[time] ?? ''}
-                  aria-label={`Schedule ${time}`}
+                  aria-label={`Schedule ${formatClock(time, timeFormat)}`}
                   list={suggestions.length > 0 ? `plan-sched-sug-${time}` : undefined}
                   onChange={(e) => patch({ schedule: { ...day.schedule, [time]: e.target.value } })}
                 />
@@ -368,7 +375,7 @@ export function ScheduleBody({
                 <button
                   type="button"
                   className={styles.rowAddBtn}
-                  aria-label={`Add task at ${time}`}
+                  aria-label={`Add task at ${formatClock(time, timeFormat)}`}
                   onClick={() => onAddTaskAt(time)}
                 >
                   +
@@ -378,6 +385,7 @@ export function ScheduleBody({
                 <SchedChip
                   key={todo.id}
                   todo={todo}
+                  timeFormat={timeFormat}
                   onToggle={() => onToggleTodo(todo.id)}
                   onOpen={onOpenTask}
                   onToggleSubtask={onToggleSubtask}
@@ -396,6 +404,7 @@ export function ScheduleBody({
                 key={todo.id}
                 todo={todo}
                 alwaysTime
+                timeFormat={timeFormat}
                 onToggle={() => onToggleTodo(todo.id)}
                 onOpen={onOpenTask}
                 onToggleSubtask={onToggleSubtask}
@@ -643,6 +652,8 @@ export interface HabitsBodyProps {
   prayerTimes?: DayPrayers | null;
   /** Prayer feature is on (a city is set) — gates the empty-city hint. */
   prayerActive?: boolean;
+  /** 24h vs 12h clock display for the prayer-time badges. */
+  timeFormat?: TimeFormat;
 }
 
 /** Fixed prayer-habit ids, for a quick "is this a timed salah" membership test. */
@@ -941,8 +952,13 @@ export function HabitsBody(props: HabitsBodyProps) {
                 streak={props.streaks[habit.id] ?? 0}
                 historyFor={props.historyFor}
                 timeBadge={
-                  habit.salah && PRAYER_ID_SET.has(habit.id)
-                    ? (props.prayerTimes?.[habit.id as PrayerKey] ?? null)
+                  habit.salah &&
+                  PRAYER_ID_SET.has(habit.id) &&
+                  props.prayerTimes?.[habit.id as PrayerKey]
+                    ? formatClock(
+                        props.prayerTimes[habit.id as PrayerKey],
+                        props.timeFormat ?? '24h',
+                      )
                     : null
                 }
               />

--- a/apps/web/src/features/daily-plan/daily-plan-time-and-day.test.tsx
+++ b/apps/web/src/features/daily-plan/daily-plan-time-and-day.test.tsx
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { addDays, format } from 'date-fns';
+import { defaultDailyPlanSettings, type Todo } from '@lifeline/shared';
+import { ThemeProvider } from '../../app/providers/theme-provider';
+import { renderWithProviders } from '../../test/harness';
+import { makeTodo, seedGuestTodos } from '../../test/test-utils';
+import { DailyPlanView } from './DailyPlanView';
+
+/**
+ * Two Daily Plan preferences: a 24h↔12h clock toggle that reformats every
+ * time display (times stay stored 24h), and a clear "you're not on today"
+ * indicator with a jump-back action when viewing another day.
+ */
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+function seedTimeFormat(fmt: '24h' | '12h') {
+  const settings = defaultDailyPlanSettings();
+  settings.timeFormat = fmt;
+  window.localStorage.setItem('daily_plan_settings', JSON.stringify(settings));
+}
+
+function renderPlan(dayToken: string, todos: Todo[] = [], onSelectDay = vi.fn()) {
+  seedGuestTodos(todos);
+  const view = renderWithProviders(
+    <ThemeProvider>
+      <DailyPlanView dayToken={dayToken} todos={todos} onSelectDay={onSelectDay} />
+    </ThemeProvider>,
+  );
+  return { ...view, onSelectDay };
+}
+
+describe('time format', () => {
+  it('12h reformats schedule hours and off-hour task chips (times stored 24h)', async () => {
+    seedTimeFormat('12h');
+    const timed = makeTodo({ title: 'Dentist', dueDate: '2026-07-09', dueTime: '13:30' });
+    renderPlan('2026-07-09', [timed]);
+
+    // Whole-hour schedule label compacts to "4 AM" (default day start = 04:00).
+    expect(await screen.findByText('4 AM')).toBeInTheDocument();
+    // The off-hour task chip shows 1:30 PM, not the stored 13:30.
+    expect(await screen.findByText('1:30 PM')).toBeInTheDocument();
+    expect(screen.queryByText('13:30')).not.toBeInTheDocument();
+    expect(screen.queryByText('04:00')).not.toBeInTheDocument();
+  });
+
+  it('24h (default) shows the stored strings verbatim', async () => {
+    const timed = makeTodo({ title: 'Dentist', dueDate: '2026-07-09', dueTime: '13:30' });
+    renderPlan('2026-07-09', [timed]);
+    expect(await screen.findByText('04:00')).toBeInTheDocument();
+    expect(await screen.findByText('13:30')).toBeInTheDocument();
+  });
+
+  it('the Customize toggle switches format and persists', async () => {
+    renderPlan('2026-07-09');
+    const user = userEvent.setup();
+    expect(await screen.findByText('04:00')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'CUSTOMIZE' }));
+    const dialog = await screen.findByRole('dialog');
+    await user.selectOptions(within(dialog).getByLabelText('Time format'), '12h');
+    await user.keyboard('{Escape}');
+
+    // Schedule reformats live…
+    expect(await screen.findByText('4 AM')).toBeInTheDocument();
+    // …and the choice persists to guest settings.
+    await waitFor(() => {
+      const raw = window.localStorage.getItem('daily_plan_settings');
+      expect((JSON.parse(raw as string) as { timeFormat: string }).timeFormat).toBe('12h');
+    });
+  });
+});
+
+describe('not-today indicator', () => {
+  const yesterday = format(addDays(new Date(), -1), 'yyyy-MM-dd');
+  const todayStr = format(new Date(), 'yyyy-MM-dd');
+
+  it('shows a banner, a real-today chip marker, and a jump-to-today pill', async () => {
+    const { onSelectDay } = renderPlan(yesterday);
+    const user = userEvent.setup();
+
+    // Banner names the day and offers a jump.
+    expect(await screen.findByText(/Yesterday — not today/)).toBeInTheDocument();
+    // The week strip marks the REAL today distinctly (aria "(today)").
+    expect(screen.getByRole('button', { name: /\(today\)$/ })).toBeInTheDocument();
+
+    // "Go to today" (banner) routes to the actual current date.
+    await user.click(screen.getByRole('button', { name: 'Go to today →' }));
+    expect(onSelectDay).toHaveBeenCalledWith(todayStr);
+
+    // The bottom pill offers the same jump.
+    expect(
+      screen.getByRole('button', { name: /Go to today \(viewing Yesterday\)/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows nothing extra when you are on today', async () => {
+    renderPlan('today');
+    // A stable today-only element proves it rendered, then assert no banner/pill.
+    expect(await screen.findByText('DAILY PLAN')).toBeInTheDocument();
+    expect(screen.queryByText(/not today/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Go to today →' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/daily-plan/lib/time-format.test.ts
+++ b/apps/web/src/features/daily-plan/lib/time-format.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { formatClock } from './time-format';
+
+/** 24h passes through; 12h renders AM/PM, compacting whole hours. */
+describe('formatClock', () => {
+  it('24h mode returns the stored string unchanged', () => {
+    expect(formatClock('05:00', '24h')).toBe('05:00');
+    expect(formatClock('13:30', '24h')).toBe('13:30');
+    expect(formatClock('00:00', '24h')).toBe('00:00');
+  });
+
+  it('12h whole hours are compact (no :00)', () => {
+    expect(formatClock('05:00', '12h')).toBe('5 AM');
+    expect(formatClock('17:00', '12h')).toBe('5 PM');
+    expect(formatClock('00:00', '12h')).toBe('12 AM'); // midnight
+    expect(formatClock('12:00', '12h')).toBe('12 PM'); // noon
+    expect(formatClock('24:00', '12h')).toBe('12 AM'); // schedule uses hour 24 → 00
+  });
+
+  it('12h off-hours keep minutes', () => {
+    expect(formatClock('13:30', '12h')).toBe('1:30 PM');
+    expect(formatClock('09:05', '12h')).toBe('9:05 AM');
+    expect(formatClock('00:15', '12h')).toBe('12:15 AM');
+    expect(formatClock('23:59', '12h')).toBe('11:59 PM');
+  });
+
+  it('returns malformed input verbatim (never blanks a row)', () => {
+    expect(formatClock('', '12h')).toBe('');
+    expect(formatClock('not a time', '12h')).toBe('not a time');
+    expect(formatClock('99:99', '12h')).toBe('99:99');
+  });
+});

--- a/apps/web/src/features/daily-plan/lib/time-format.ts
+++ b/apps/web/src/features/daily-plan/lib/time-format.ts
@@ -1,0 +1,29 @@
+import type { DailyPlanSettings } from '@lifeline/shared';
+
+/**
+ * Clock display for the Daily Plan. All times are STORED 24-hour (schedule
+ * keys `HH:00`, task `dueTime` `HH:mm`, prayer times `HH:MM`); this only
+ * changes how they're shown. 24h mode passes the string through unchanged;
+ * 12h mode renders AM/PM, dropping `:00` so whole hours read compactly
+ * (`5 AM`, `12 PM`) while off-hours keep minutes (`1:30 PM`).
+ *
+ * Pure and defensive: anything that isn't a valid `H:MM`/`HH:MM` is returned
+ * verbatim, so a malformed value can never blank out or crash a row.
+ */
+
+export type TimeFormat = DailyPlanSettings['timeFormat'];
+
+const HHMM = /^(\d{1,2}):(\d{2})$/;
+
+export function formatClock(raw: string, format: TimeFormat): string {
+  if (format === '24h') return raw;
+  const match = HHMM.exec(raw.trim());
+  if (!match) return raw;
+  const rawHour = Number(match[1]);
+  const minute = match[2] as string;
+  if (rawHour > 24 || Number(minute) > 59) return raw;
+  const hour = rawHour % 24; // schedule can hand us hour 24 (midnight)
+  const period = hour < 12 ? 'AM' : 'PM';
+  const hour12 = hour % 12 === 0 ? 12 : hour % 12; // 0/12/24 → 12
+  return minute === '00' ? `${hour12} ${period}` : `${hour12}:${minute} ${period}`;
+}

--- a/packages/shared/src/daily-plan.test.ts
+++ b/packages/shared/src/daily-plan.test.ts
@@ -79,6 +79,7 @@ describe('dailyPlanSettingsSchema', () => {
     expect(settings.priorityCount).toBe(3);
     expect(settings.gratitudeCount).toBe(3);
     expect(settings.tomorrowCount).toBe(4);
+    expect(settings.timeFormat).toBe('24h');
     expect(settings.templates).toEqual({});
     // Prayer times default dormant (no city/coords) with Auto calculation method.
     expect(settings.prayer).toEqual({

--- a/packages/shared/src/daily-plan.ts
+++ b/packages/shared/src/daily-plan.ts
@@ -360,6 +360,9 @@ export const dailyPlanSettingsSchema = z.object({
   /** Content text scale inside the plan cards — 's' is the original desktop
       density; 'm' (default) and 'l' step fonts/controls up for phones. */
   textScale: z.enum(['s', 'm', 'l']).default('m'),
+  /** Clock display across the plan — 24-hour (default, e.g. 17:30) or 12-hour
+      AM/PM (5:30 PM). Times are stored 24h; this only affects rendering. */
+  timeFormat: z.enum(['24h', '12h']).default('24h'),
   secOrder: z.array(planKey).max(32).default([]),
   secWide: boundedRecord(z.boolean(), 32).default({}),
   hidden: boundedRecord(z.boolean(), 32).default({}),


### PR DESCRIPTION
## Summary

Two Daily Plan preferences.

### 1. Time format toggle (24-hour ↔ 12-hour AM/PM)
A new **Customize → Schedule &amp; rows → Time format** control switches every clock display between **24-hour** (default, `17:30`) and **12-hour** (`5:30 PM`). Times stay **stored 24h** — only rendering changes.

- A pure `lib/time-format.ts` `formatClock(raw, fmt)` does the conversion, compacting whole hours in 12h (`5 AM`, `12 PM`) while off-hours keep minutes (`1:30 PM`); malformed input is returned verbatim so a bad value can never blank a row.
- Applied to: schedule hour labels + their aria-labels, off-hour task time chips, prayer-time badges, the task-preview meta line, and the Customize `DAY STARTS`/`DAY ENDS` option labels.
- **Untouched on purpose** (they must stay raw 24h): the now-band match (`time === nowLabel`), off-hour grouping (`dueTime.slice(0,3)` / `.endsWith(':00')`), `datalist` ids, and the native time `<input>` (the OS renders that one).

### 2. "Not today" indicator + jump back
Viewing another day was silent — the masthead even highlighted the *selected* chip as if it were "today". Now:

- The week strip **fills the day you're viewing** and marks the **real today with a dot** (+ `aria-current="date"` on the actual current date).
- A banner under the masthead: **"Viewing Yesterday — not today · Go to today →"** (relative label: Yesterday / Tomorrow / `Wed, Jul 8`).
- A bottom-left **"↩ Today" pill**, lifted to sit **above** the center JumpSheet pill so the two never overlap on narrow phones.
- **"Go to today"** collapses to the canonical `/` route (via `dayRouteToken`) instead of `/day/<today>`.

- **shared:** additive `timeFormat: '24h' | '12h'` (default `24h`) on `DailyPlanSettings` — old blobs self-heal.

**Verified in-browser** (guest, paper theme): 12h schedule renders `4 AM … 1:30 PM` with no raw `13:30` leak; the Customize toggle flips and persists; viewing yesterday shows the banner, the viewed-day chip filled with a dot on the real today, and the bottom "↩ Today" pill — measured on a 360px phone the Today pill now sits ~17px above the JumpSheet pill (zero overlap). Full web suite green (**303**), shared **44**, server **370**; lint, prettier, typecheck clean.

> **Adversarial multi-agent review complete.** 4 candidate findings, each independently verified: 3 were false positives (an out-of-Daily-Plan-scope Tasks-page time; an `aria-current` nicety already covered by the prominent masthead date label; the banner-vs-pill "redundancy" — they are structurally different since the banner scrolls away and the pill persists). **1 was confirmed and fixed** — the return-to-today pill could overlap the JumpSheet pill's gesture surface on narrow phones (commit `a075dce`).

## Change Type
- [x] Product behavior
- [ ] Feature scope
- [x] Frontend behavior
- [ ] Backend behavior
- [ ] API contract
- [x] Data model
- [ ] Architecture
- [ ] Operations / deployment

## Documentation Impact
- [x] I evaluated documentation impact.
- [ ] I updated the relevant docs.
- [x] No docs update was needed, and I explained why below.

## Docs Updated

None.

## If no docs were updated, explain why

The only contract change is an additive settings field (`timeFormat`) with a schema default — old blobs parse unchanged. No public API, endpoint, or documented interface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBY1ikvNFrfGjqtERp8WFV)_